### PR TITLE
[codex] Restore KeePass foreground after WinHello auth

### DIFF
--- a/src/AuthProviders/UIContext.cs
+++ b/src/AuthProviders/UIContext.cs
@@ -24,10 +24,12 @@ namespace KeePassWinHello
         private readonly LinkedList<UIContext> _contexts = new LinkedList<UIContext>();
         private readonly object _lock = new object();
         private readonly HDESK _mainDesktop;
+        private readonly IWin32Window _mainWindow;
 
-        public UIContextManager(HDESK mainDesktop)
+        public UIContextManager(HDESK mainDesktop, IWin32Window mainWindow)
         {
             _mainDesktop = mainDesktop;
+            _mainWindow = mainWindow;
         }
 
         public UIContext CurrentContext
@@ -43,6 +45,7 @@ namespace KeePassWinHello
         }
 
         public HDESK MainDesktop { get { return _mainDesktop; } }
+        public HWND MainWindowHandle { get { return new HWND(_mainWindow.Handle); } }
 
         public IDisposable PushContext(string message, IWin32Window parentWindow)
         {

--- a/src/AuthProviders/WinHelloProviderForegroundDecorator.cs
+++ b/src/AuthProviders/WinHelloProviderForegroundDecorator.cs
@@ -61,8 +61,10 @@ namespace KeePassWinHello
         {
             try
             {
-                var keePassWindowHandle = _uiContextManager.CurrentContext.ParentWindowHandle; //should not be null
-                Win32Window.GetOrNull(keePassWindowHandle).EnsureForeground();
+                var keePassWindowHandle = _uiContextManager.MainWindowHandle;
+                var keePassWindow = Win32Window.GetOrNull(keePassWindowHandle);
+                if (keePassWindow != null)
+                    keePassWindow.EnsureForeground();
             }
             catch (Exception ex)
             {

--- a/src/KeePassWinHelloExt.cs
+++ b/src/KeePassWinHelloExt.cs
@@ -48,7 +48,7 @@ namespace KeePassWinHello
             if (host == null) { return false; }
 
             var mainDesktop = WinAPI.GetThreadDesktop(WinAPI.GetCurrentThreadId());
-            _uiContextManager = new UIContextManager(mainDesktop);
+            _uiContextManager = new UIContextManager(mainDesktop, host.MainWindow);
             _uiContext = _uiContextManager.PushContext("KeePass: Main Window", host.MainWindow);
 
             Settings.Instance.Initialize(host.CustomConfig, _uiContextManager);


### PR DESCRIPTION
## Summary

Fixes #107 by restoring the stable KeePass main window after successful Windows Hello authentication instead of restoring the transient key prompt context.

The 3.3 UI context work correctly lets the Windows Hello prompt use the nearest active dialog as its parent, but the foreground decorator also used that same current context after decrypting. During unlock, that context is the `KeyPromptForm`, so the post-auth foreground helper could focus/minimize the wrong window and leave KeePass minimized to tray.

This keeps prompt parenting and context messages unchanged, while adding a main-window reference to `UIContextManager` for post-auth foreground restoration.

## Validation

- Subagent review found no blocking correctness issues.
- `git diff --check` passed except for existing CRLF conversion warnings.
- `dotnet build src\KeePassWinHello.sln` could not complete in this local environment because required project prerequisites are missing: .NET Framework v4.0 reference assemblies, `src/lib/KeePass.exe`, and SDK resource dependencies for the debug project.