### PR TITLE
[codex] Treat Windows Hello key timeout as cancellation

### DIFF
--- a/src/AuthProviders/WinHelloProvider.cs
+++ b/src/AuthProviders/WinHelloProvider.cs
@@ -33,6 +33,7 @@ namespace KeePassWinHello
         private const int TPM_20_E_HANDLE = unchecked((int)0x8028008B);
         private const int TPM_20_E_SIZE = unchecked((int)0x80280095);
         private const int TPM_20_E_159 = unchecked((int)0x80280159);
+        private const int HRESULT_FROM_WIN32_WAIT_TIMEOUT = unchecked((int)0x80070102);
         private const int ERROR_CANCELLED = unchecked((int)0x800704C7);
         private const int WINBIO_E_DATA_PROTECTION_FAILURE = unchecked((int)0x80098046); // The biometric service could not decrypt the data.
 
@@ -471,7 +472,10 @@ namespace KeePassWinHello
 
                 ApplyUIContext(ngcKeyHandle);
 
-                NCryptFinalizeKey(ngcKeyHandle, 0).ThrowOnError("NCryptFinalizeKey");
+                var finalizeStatus = NCryptFinalizeKey(ngcKeyHandle, 0);
+                if (finalizeStatus.secStatus == HRESULT_FROM_WIN32_WAIT_TIMEOUT)
+                    throw new AuthProviderUserCancelledException();
+                finalizeStatus.ThrowOnError("NCryptFinalizeKey");
             }
 
             return ngcKeyHandle;


### PR DESCRIPTION
## Summary

- Treat HRESULT_FROM_WIN32(WAIT_TIMEOUT) from NCryptFinalizeKey as a Windows Hello cancellation outcome.
- Preserve existing timeout/error behavior for other NCrypt operations.

## Why

When persistent key creation times out waiting for Windows Hello authorization, the plugin currently reports a generic system error and asks users to file a bug. The timeout should flow through the existing friendly cancellation path instead.

Closes #89.

## Validation

- git diff --check
- Sub-agent implementation pass completed.
- Sub-agent review pass found the first implementation was too broad; fixed by scoping timeout handling to NCryptFinalizeKey only and renaming the HRESULT constant.

Build was attempted with dotnet build src\KeePassWinHello.sln -c Release /p:DefineConstants=MONO, but this environment is missing .NET Framework 4.0 reference assemblies and the KeePass reference used by the project worktree.