### PR TITLE
[codex] Document Windows Hello method selection limit

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -35,6 +35,11 @@ This plugin relies on Windows Hello API and its [requirements][WinHelloReq].
 There are some known issues with Windows Hello reported by community.
 Please, check [here](https://github.com/sirAndros/KeePassWinHello/wiki/Windows-Hello-issues) before write issue.
 
+KeePassWinHello cannot select or remember a preferred Windows Hello method or device
+such as face, fingerprint, or PIN. The plugin asks Windows Hello to authorize a
+cryptographic key operation; Windows controls the available authentication methods
+and the method shown by the Windows Hello dialog.
+
 Tested on Microsoft Surface Pro 2017 with KeePass 2.39.1 and 2.42.1.
 
 [WinHelloReq]: https://www.microsoft.com/en-US/windows/windows-10-specifications


### PR DESCRIPTION
## Summary

- Document that KeePassWinHello cannot select or remember a preferred Windows Hello method or device.
- Clarify that the plugin asks Windows Hello to authorize a cryptographic key operation, while Windows controls available methods and the method shown by the dialog.

## Why

Issue #13 asks the plugin to remember a preferred Face/IR, fingerprint, or PIN method. The current CNG/Microsoft Passport integration exposes prompt context and key-operation authorization, but not a supported modality/device selector. Adding a fake option would misrepresent plugin control and risk changing security-sensitive prompt behavior without a real implementation path.

Refs #13.

## Validation

- Worker sub-agent investigated the CNG/Windows Hello path and found no supported modality/device selection property in the repo integration surface.
- Reviewer sub-agent found no actionable issues and recommended a docs-only PR using Refs rather than Fixes.
- git diff --check

Build was not run because this is a README-only documentation change.