### PR TITLE
[codex] Update key invalidation period options

### DIFF
--- a/src/Settings/OptionsPanel.Designer.cs
+++ b/src/Settings/OptionsPanel.Designer.cs
@@ -184,7 +184,6 @@
             "Never",
             "1 Minute",
             "5 Minutes",
-            "10 Minutes",
             "15 Minutes",
             "30 Minutes",
             "1 Hour",

--- a/src/Settings/OptionsPanel.cs
+++ b/src/Settings/OptionsPanel.cs
@@ -397,17 +397,16 @@ namespace KeePassWinHello
                 case 0: return VALID_UNLIMITED;
                 case 1: return VALID_1MINUTE;
                 case 2: return VALID_5MINUTES;
-                case 3: return VALID_10MINUTES;
-                case 4: return VALID_15MINUTES;
-                case 5: return VALID_30MINUTES;
-                case 6: return VALID_1HOUR;
-                case 7: return VALID_2HOURS;
-                case 8: return VALID_6HOURS;
-                case 9: return VALID_12HOURS;
-                case 10: return VALID_1DAY;
-                case 11: return VALID_3DAYS;
-                case 12: return VALID_7DAYS;
-                case 13: return VALID_MONTH;
+                case 3: return VALID_15MINUTES;
+                case 4: return VALID_30MINUTES;
+                case 5: return VALID_1HOUR;
+                case 6: return VALID_2HOURS;
+                case 7: return VALID_6HOURS;
+                case 8: return VALID_12HOURS;
+                case 9: return VALID_1DAY;
+                case 10: return VALID_3DAYS;
+                case 11: return VALID_7DAYS;
+                case 12: return VALID_MONTH;
                 default: return VALID_DEFAULT;
             }
         }
@@ -420,17 +419,17 @@ namespace KeePassWinHello
                 case VALID_1MINUTE: return 1;
                 case VALID_5MINUTES: return 2;
                 case VALID_10MINUTES: return 3;
-                case VALID_15MINUTES: return 4;
-                case VALID_30MINUTES: return 5;
-                case VALID_1HOUR: return 6;
-                case VALID_2HOURS: return 7;
-                case VALID_6HOURS: return 8;
-                case VALID_12HOURS: return 9;
-                case VALID_1DAY: return 10;
-                case VALID_3DAYS: return 11;
-                case VALID_7DAYS: return 12;
-                case VALID_MONTH: return 13;
-                default: return 10;
+                case VALID_15MINUTES: return 3;
+                case VALID_30MINUTES: return 4;
+                case VALID_1HOUR: return 5;
+                case VALID_2HOURS: return 6;
+                case VALID_6HOURS: return 7;
+                case VALID_12HOURS: return 8;
+                case VALID_1DAY: return 9;
+                case VALID_3DAYS: return 10;
+                case VALID_7DAYS: return 11;
+                case VALID_MONTH: return 12;
+                default: return 9;
             }
         }
 


### PR DESCRIPTION
## What changed

- Removed `10 Minutes` from the saved-key invalidation dropdown.
- Kept the existing `3 Days` option available in the same dropdown.
- Updated the dropdown index mapping after removing the 10-minute row.
- Preserved compatibility with existing configurations that already contain the 10-minute value by showing them as the nearest remaining visible option, `15 Minutes`.

## Why

Issue #40 asks for safer saved-key invalidation behavior and discusses scan-attempt limits. The scan-attempt part is not implemented here because KeePassWinHello delegates the biometric prompt to Windows Hello/CNG. The plugin does not receive per-failed-scan events, so adding a setting named as a scan-attempt limit would not actually control fingerprint attempts. Reusing the existing provider retry count would be misleading because that value applies to whole retryable provider/system operations, not individual biometric scans inside the Windows Hello prompt.

This PR implements the low-risk, defensible part: removing the very short 10-minute retention option while preserving existing saved settings without breaking option loading.

Refs #40

## Validation

- Worker subagent implemented the change in an isolated branch.
- Reviewer subagent checked the mapping and found no actionable issues.
- `git diff --check`
- `MSBuild.exe src\KeePassWinHello.csproj /t:Rebuild /p:Configuration=Release /p:DefineConstants=MONO /p:FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319 /p:ReferencePath=C:\proj\KeePassWinHello\lib`