### PR TITLE
[codex] Bring Auto-Type selection to foreground

### DIFF
--- a/src/KeePassWinHelloExt.cs
+++ b/src/KeePassWinHelloExt.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.Reflection;
+using System.Windows.Forms;
 using KeePass.Forms;
 using KeePass.Plugins;
 using KeePass.UI;
@@ -113,6 +114,13 @@ namespace KeePassWinHello
                     }
                 }
 
+                var autoTypeCtxForm = e.Form as AutoTypeCtxForm;
+                if (autoTypeCtxForm != null)
+                {
+                    BringAutoTypeSelectionToFront(autoTypeCtxForm);
+                    return;
+                }
+
                 var optionsForm = e.Form as OptionsForm;
                 if (optionsForm != null)
                 {
@@ -127,6 +135,45 @@ namespace KeePassWinHello
             catch (Exception ex)
             {
                 _uiContextManager.CurrentContext.ShowError(ex);
+            }
+        }
+
+        private static void BringAutoTypeSelectionToFront(AutoTypeCtxForm autoTypeCtxForm)
+        {
+            try
+            {
+                autoTypeCtxForm.BeginInvoke(new MethodInvoker(delegate
+                {
+                    try
+                    {
+                        if (autoTypeCtxForm.IsDisposed)
+                            return;
+
+                        var window = Win32Window.From(autoTypeCtxForm.Handle);
+                        if (window != null)
+                            window.EnsureForeground();
+
+                        bool topMost = autoTypeCtxForm.TopMost;
+                        try
+                        {
+                            autoTypeCtxForm.TopMost = true;
+                            autoTypeCtxForm.BringToFront();
+                            autoTypeCtxForm.Activate();
+                        }
+                        finally
+                        {
+                            autoTypeCtxForm.TopMost = topMost;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.Fail(ex.Message);
+                    }
+                }));
+            }
+            catch (Exception ex)
+            {
+                Debug.Fail(ex.Message);
             }
         }
     }


### PR DESCRIPTION
## What changed

- Detect KeePass `AutoTypeCtxForm` windows when KeePass creates them through `GlobalWindowManager.WindowAdded`.
- Schedule a UI-thread foreground operation for the Auto-Type selection window.
- Temporarily set the form `TopMost`, call `BringToFront()` and `Activate()`, then restore the previous `TopMost` value in a `finally` block.

## Why

Issue #48 reports that, after Windows Hello unlock during global Auto-Type, the KeePass Auto-Type selection window can appear behind the current target application. That leaves the user in an awkward state because KeePass has unlocked but the selection UI is not visible/focused.

This PR implements the narrow part that is safe from inside this plugin: when KeePass creates the Auto-Type selection form, bring that KeePass-owned form to the foreground.

## Scope deliberately not changed

This does not change Windows Hello/CNG prompt parent selection and does not change database relock behavior after Auto-Type. A broader worker attempt was rejected during review because it depended on brittle KeePass stack-frame detection, could leave stale relock state that later locks all databases after an unrelated Auto-Type send, and did not actually reach the nested CNG prompt context used by `KeyManager.ExtractCompositeKey`.

Those parts need a deeper design and manual validation on a real multi-monitor, non-RDP Windows setup. This PR is therefore partial and uses `Refs #48`, not `Fixes #48`.

Refs #48

## Validation

- Worker subagent produced an initial patch in an isolated branch.
- Reviewer subagent rejected the broad patch; the branch was trimmed to the reviewed safe subset.
- Reviewer subagent approved the narrowed patch with one hardening nit, which was applied.
- `git diff --check` passed with only Git LF-to-CRLF working-copy warnings.
- `MSBuild.exe src\KeePassWinHello.csproj /t:Rebuild /p:Configuration=Release /p:DefineConstants=MONO /p:FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319 /p:ReferencePath=C:\proj\KeePassWinHello\lib` passed with 0 warnings and 0 errors.

## Manual test needed

- Global Auto-Type with multiple matching entries.
- KeePass behind the target application.
- KeePass and target application on different monitors.
- Non-RDP session, because Windows Hello is intentionally disabled over RDP.