### PR TITLE
[codex] Center Windows Hello prompt without visible parent

### DIFF
--- a/src/AuthProviders/UIContext.cs
+++ b/src/AuthProviders/UIContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace KeePassWinHello
@@ -10,12 +11,106 @@ namespace KeePassWinHello
         public string Message { get; private set; }
         public HWND ParentWindowHandle { get; private set; }
 
+        private readonly Control _uiThreadControl;
+        private Form _promptParentWindow;
+
         IntPtr IWin32Window.Handle { get { return ParentWindowHandle.Value; } }
 
         public UIContext(string message, HWND windowHandle)
         {
             Message = message;
             ParentWindowHandle = windowHandle;
+        }
+
+        public UIContext(string message, IWin32Window parentWindow)
+            : this(message, new HWND(parentWindow.Handle))
+        {
+            _uiThreadControl = parentWindow as Control;
+        }
+
+        public HWND PromptParentWindowHandle
+        {
+            get
+            {
+                if (Win32Window.IsVisibleAndNotMinimized(ParentWindowHandle))
+                    return ParentWindowHandle;
+
+                return EnsurePromptParentWindowHandle();
+            }
+        }
+
+        public void DisposePromptParentWindow()
+        {
+            if (ShouldInvokeOnUIThread())
+            {
+                _uiThreadControl.Invoke(new MethodInvoker(DisposePromptParentWindowOnCurrentThread));
+                return;
+            }
+
+            DisposePromptParentWindowOnCurrentThread();
+        }
+
+        private void DisposePromptParentWindowOnCurrentThread()
+        {
+            if (_promptParentWindow != null)
+            {
+                _promptParentWindow.Dispose();
+                _promptParentWindow = null;
+            }
+        }
+
+        private HWND EnsurePromptParentWindowHandle()
+        {
+            if (ShouldInvokeOnUIThread())
+            {
+                return (HWND)_uiThreadControl.Invoke(new Func<HWND>(EnsurePromptParentWindowHandleOnCurrentThread));
+            }
+
+            return EnsurePromptParentWindowHandleOnCurrentThread();
+        }
+
+        private HWND EnsurePromptParentWindowHandleOnCurrentThread()
+        {
+            if (_promptParentWindow == null || _promptParentWindow.IsDisposed)
+                _promptParentWindow = PromptParentForm.CreateCentered();
+
+            return new HWND(_promptParentWindow.Handle);
+        }
+
+        private bool ShouldInvokeOnUIThread()
+        {
+            return _uiThreadControl != null
+                && !_uiThreadControl.IsDisposed
+                && _uiThreadControl.InvokeRequired;
+        }
+
+        private sealed class PromptParentForm : Form
+        {
+            private PromptParentForm()
+            {
+                FormBorderStyle = FormBorderStyle.None;
+                Opacity = 0.01;
+                ShowInTaskbar = false;
+                Size = new Size(1, 1);
+                StartPosition = FormStartPosition.Manual;
+                Text = Settings.ProductName;
+            }
+
+            protected override bool ShowWithoutActivation
+            {
+                get { return true; }
+            }
+
+            public static PromptParentForm CreateCentered()
+            {
+                PromptParentForm form = new PromptParentForm();
+                Rectangle workingArea = Screen.FromPoint(Cursor.Position).WorkingArea;
+                form.Location = new Point(
+                    workingArea.Left + (workingArea.Width - form.Width) / 2,
+                    workingArea.Top + (workingArea.Height - form.Height) / 2);
+                form.Show();
+                return form;
+            }
         }
     }
 
@@ -46,7 +141,7 @@ namespace KeePassWinHello
 
         public IDisposable PushContext(string message, IWin32Window parentWindow)
         {
-            var context = new UIContext(message, new HWND(parentWindow.Handle));
+            var context = new UIContext(message, parentWindow);
             _contexts.AddFirst(context);
             return new Disposer(this, context);
         }
@@ -66,6 +161,7 @@ namespace KeePassWinHello
             {
                 bool removed = _contextManager._contexts.Remove(_context);
                 Debug.Assert(removed);
+                _context.DisposePromptParentWindow();
             }
         }
     }

--- a/src/AuthProviders/WinHelloProvider.cs
+++ b/src/AuthProviders/WinHelloProvider.cs
@@ -482,7 +482,7 @@ namespace KeePassWinHello
             var uiContext = _uiContextManager.CurrentContext;
             if (uiContext != null)
             {
-                IntPtr parentWindowHandle = uiContext.ParentWindowHandle.Value;
+                IntPtr parentWindowHandle = uiContext.PromptParentWindowHandle.Value;
                 if (parentWindowHandle != IntPtr.Zero)
                 {
                     byte[] handle = BitConverter.GetBytes(IntPtr.Size == 8 ? parentWindowHandle.ToInt64() : parentWindowHandle.ToInt32());

--- a/src/Utilities/Win32Window.cs
+++ b/src/Utilities/Win32Window.cs
@@ -99,6 +99,13 @@ namespace KeePassWinHello
             return null;
         }
 
+        public static bool IsVisibleAndNotMinimized(HWND hwnd)
+        {
+            return hwnd.IsValid
+                && WinAPI.IsWindowVisible(hwnd.Value).Result
+                && !WinAPI.IsIconic(hwnd.Value).Result;
+        }
+
         #endregion Creation
 
 
@@ -233,6 +240,12 @@ namespace KeePassWinHello
 
             [DllImport(User32, SetLastError = true, CharSet = CharSet.Unicode)]
             public static extern HWND FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string lpClassName, string lpWindowName);
+
+            [DllImport(User32, SetLastError = true)]
+            public static extern BOOL IsWindowVisible(IntPtr hWnd);
+
+            [DllImport(User32, SetLastError = true)]
+            public static extern BOOL IsIconic(IntPtr hWnd);
         }
     }
 }


### PR DESCRIPTION
## What changed

- Added `UIContext.PromptParentWindowHandle` for Windows Hello prompt parenting.
- Kept the existing `ParentWindowHandle` unchanged for normal UI context behavior and foreground restoration.
- When the current context parent is visible and not minimized, Windows Hello still receives that original KeePass/KeePass prompt HWND.
- When the parent HWND is hidden, minimized, or unavailable, the plugin creates a short-lived KeePass-process helper form centered on the screen under the cursor and passes that HWND to CNG.
- Disposes the helper when the pushed UI context exits.
- Marshals helper creation/disposal to the captured WinForms UI thread when the current caller is on another thread.
- Added Win32 helpers for `IsWindowVisible` and `IsIconic`.

## Why

Issue #54 reports that when KeePass is minimized or hidden in the tray, the Windows Hello dialog can appear at the top-left of the screen. The existing code always passes the current UI context parent HWND to `NCRYPT_WINDOW_HANDLE_PROPERTY`. If that parent is hidden/minimized, Windows has no useful visible anchor for prompt placement.

The fix keeps normal visible-parent behavior unchanged and adds a fallback parent only for the hidden/minimized case. This avoids the unsafe approaches rejected in earlier foreground work: it does not search for or foreground Windows credential dialogs, does not parent the prompt to arbitrary external windows, and does not call the existing `EnsureForeground` path that can minimize KeePass windows.

Refs #54

## Review notes

The reviewer raised a thread-affinity issue in the first pass. The patch now captures the original WinForms parent control and uses `Control.Invoke` for helper form creation/disposal when needed. The second review found no blocking issues.

Residual risk remains UI/manual: helper ownership and prompt placement need real Windows Hello validation on a non-RDP desktop with KeePass hidden, minimized, and in tray.

## Validation

- Worker subagent implemented the fix in an isolated branch.
- Reviewer subagent reviewed the patch twice; first pass found thread-affinity risk, second pass found no blocking issues.
- `git diff --check` passed with only Git LF-to-CRLF working-copy warnings.
- `MSBuild.exe src\KeePassWinHello.csproj /t:Rebuild /p:Configuration=Release /p:DefineConstants=MONO /p:FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319 /p:ReferencePath=C:\proj\KeePassWinHello\lib` passed with 0 warnings and 0 errors.

## Manual test needed

- KeePass minimized, hidden, and tray unlock paths.
- Multi-monitor behavior, especially cursor on a non-primary screen.
- Persistent-key creation from Options with visible parent.
- Secure desktop enabled/disabled.
- Elevated KeePass foreground behavior.