### PR TITLE
[codex] Handle CredWrite memory failures

### DIFF
--- a/src/Exceptions/KeyStorageException.cs
+++ b/src/Exceptions/KeyStorageException.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace KeePassWinHello
+{
+    [Serializable]
+    public class KeyStorageException : KeePassWinHelloException
+    {
+        public override bool IsPresentable { get { return true; } }
+
+        public KeyStorageException(string message) : base(message) { }
+        public KeyStorageException(string message, Exception inner) : base(message, inner) { }
+        protected KeyStorageException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/KeePassWinHello.csproj
+++ b/src/KeePassWinHello.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Exceptions\AuthProviderInvalidKeyException.cs" />
     <Compile Include="Exceptions\AuthProviderSystemErrorException.cs" />
     <Compile Include="Exceptions\AuthProviderException.cs" />
+    <Compile Include="Exceptions\KeyStorageException.cs" />
     <Compile Include="AuthProviders\IAuthProvider.cs" />
     <Compile Include="AuthProviders\UIContext.cs" />
     <Compile Include="AuthProviders\WinHelloProviderForegroundDecorator.cs" />

--- a/src/KeyManagement/Storage/KeyWindowsStorage.cs
+++ b/src/KeyManagement/Storage/KeyWindowsStorage.cs
@@ -10,6 +10,7 @@ namespace KeePassWinHello
     internal class KeyWindowsStorage : IKeyStorage
     {
         #region Credential Manager API
+        private const int ERROR_NOT_ENOUGH_MEMORY = 0x8;
         private const int ERROR_NOT_FOUND = 0x490;
 
         private const int CRED_TYPE_GENERIC = 0x1;
@@ -96,7 +97,21 @@ namespace KeePassWinHello
                     Marshal.Copy(data, 0, ncred.CredentialBlob, data.Length);
                     ncred.CredentialBlobSize = (uint)data.Length;
 
-                    CredWrite(ref ncred, 0).ThrowOnError("CredWrite");
+                    try
+                    {
+                        CredWrite(ref ncred, 0).ThrowOnError("CredWrite");
+                    }
+                    catch (EnviromentErrorException ex)
+                    {
+                        if (ex.ErrorCode != ERROR_NOT_ENOUGH_MEMORY)
+                            throw;
+
+                        throw new KeyStorageException(
+                            "Windows Credential Manager reported that there was not enough memory to store this database key (CredWrite error 0x8)." +
+                            Environment.NewLine +
+                            "The database was locked, but the key was not saved for Windows Hello unlock. KeePass may ask for the regular master key next time.",
+                            ex);
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
## What changed

- Added `KeyStorageException`, a presentable exception type for user-facing key-storage failures.
- Mapped `CredWrite` `ERROR_NOT_ENOUGH_MEMORY` / `0x8` to a clear warning message when Windows Credential Manager cannot store the database key.
- Kept all other `CredWrite` / Credential Manager failures on the existing reportable error path.
- Updated the legacy `KeePassWinHello.csproj` so the new exception is included in PLGX/legacy builds.

## Why

Issue #67 reports a generic bug-report dialog when `KeyWindowsStorage.AddOrUpdate` fails with `CredWrite` error `0x8` during database locking.

The Credential Manager blob is already capped at 2560 bytes before `CredWrite`, matching the generic credential blob limit, and the existing interop layout matches the Windows `CREDENTIAL` fields used here. I did not find evidence that this specific report is caused by oversized serialized key data or an obvious marshaling bug.

The immediate problem is that Windows returns a known storage failure, but the plugin displays it as an unexpected internal error. This PR keeps the failure visible and does not silently fall back to another storage mode, but it explains the actual user impact: the database was locked, the key was not stored in Credential Manager, and KeePass may require the regular master key next time.

Refs #67

## Behavior notes

This does not change persistent-storage semantics. If Credential Manager cannot write the key, the operation still fails visibly instead of pretending the key was saved.

## Validation

- Worker subagent implemented the narrow fix in an isolated branch.
- Reviewer subagent found no blocking issues and verified that the new exception uses the presentable-message path.
- `git diff --check` passed with only Git LF-to-CRLF working-copy warnings.
- `MSBuild.exe src\KeePassWinHello.csproj /t:Rebuild /p:Configuration=Release /p:DefineConstants=MONO /p:FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319 /p:ReferencePath=C:\proj\KeePassWinHello\lib` passed with 0 warnings and 0 errors.

## Manual test needed

- A real Credential Manager `CredWrite` failure with error `0x8` to confirm the warning text appears instead of the generic report dialog.