### PR TITLE
[codex] Handle CredWrite logon session failures

### DIFF
--- a/src/Exceptions/KeyStorageException.cs
+++ b/src/Exceptions/KeyStorageException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace KeePassWinHello
+{
+    [Serializable]
+    public class KeyStorageException : KeePassWinHelloException
+    {
+        public override bool IsPresentable { get { return true; } }
+
+        public KeyStorageException(string message) : base(message) { }
+        public KeyStorageException(string message, Exception inner) : base(message, inner) { }
+        protected KeyStorageException() { }
+        protected KeyStorageException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/KeePassWinHello.csproj
+++ b/src/KeePassWinHello.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Exceptions\AuthProviderInvalidKeyException.cs" />
     <Compile Include="Exceptions\AuthProviderSystemErrorException.cs" />
     <Compile Include="Exceptions\AuthProviderException.cs" />
+    <Compile Include="Exceptions\KeyStorageException.cs" />
     <Compile Include="AuthProviders\IAuthProvider.cs" />
     <Compile Include="AuthProviders\UIContext.cs" />
     <Compile Include="AuthProviders\WinHelloProviderForegroundDecorator.cs" />

--- a/src/KeyManagement/KeyManager.cs
+++ b/src/KeyManagement/KeyManager.cs
@@ -198,6 +198,10 @@ namespace KeePassWinHello
             {
                 // it's OK
             }
+            catch (KeyStorageException ex)
+            {
+                _uiContextManager.CurrentContext.ShowError(ex);
+            }
         }
 
         public void RevokeAll()

--- a/src/KeyManagement/Storage/KeyWindowsStorage.cs
+++ b/src/KeyManagement/Storage/KeyWindowsStorage.cs
@@ -11,6 +11,7 @@ namespace KeePassWinHello
     {
         #region Credential Manager API
         private const int ERROR_NOT_FOUND = 0x490;
+        private const int ERROR_NO_SUCH_LOGON_SESSION = 0x520;
 
         private const int CRED_TYPE_GENERIC = 0x1;
 
@@ -96,7 +97,7 @@ namespace KeePassWinHello
                     Marshal.Copy(data, 0, ncred.CredentialBlob, data.Length);
                     ncred.CredentialBlobSize = (uint)data.Length;
 
-                    CredWrite(ref ncred, 0).ThrowOnError("CredWrite");
+                    WriteCredential(ref ncred);
                 }
                 finally
                 {
@@ -108,6 +109,38 @@ namespace KeePassWinHello
             finally
             {
                 MemUtil.ZeroByteArray(data);
+            }
+        }
+
+        private static void WriteCredential(ref CREDENTIAL credential)
+        {
+            if (CredWrite(ref credential, 0).Result)
+                return;
+
+            int errorCode = Marshal.GetLastWin32Error();
+            if (errorCode == ERROR_NO_SUCH_LOGON_SESSION)
+                throw new KeyStorageException(GetNoLogonSessionMessage());
+
+            throw new EnviromentErrorException("CredWrite", errorCode);
+        }
+
+        private static string GetNoLogonSessionMessage()
+        {
+            string message = "Windows Credential Manager cannot save the database key because Windows reported that the current logon session is not available. The database key was not saved persistently.";
+            if (IsCurrentProcessElevatedSafe())
+                message += " This can happen when KeePass is running as Administrator; restart KeePass without elevation to use Credential Manager storage.";
+            return message;
+        }
+
+        private static bool IsCurrentProcessElevatedSafe()
+        {
+            try
+            {
+                return UAC.IsCurrentProcessElevated;
+            }
+            catch
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
## What changed

- Added `KeyStorageException`, a presentable exception type for user-facing key-storage failures.
- Mapped `CredWrite` `ERROR_NO_SUCH_LOGON_SESSION` / `0x520` to a clear warning message when Windows Credential Manager cannot save the database key.
- Added elevated-process guidance to that warning when KeePass is running as Administrator.
- Kept all other `CredWrite` failures on the existing reportable error path.
- Updated the legacy `KeePassWinHello.csproj` so the new exception is included in PLGX/legacy builds.

## Why

Issue #82 reports repeated generic bug-report dialogs from `CredWrite` error `0x520` while persistent storage is enabled and KeePass is running elevated.

Windows error `0x520` is `ERROR_NO_SUCH_LOGON_SESSION`: Windows Credential Manager cannot access the relevant logon session for the write. In this case the plugin should not tell users this is an unexpected internal bug; it should explain that the persistent key was not saved and point at the elevated-process condition when applicable.

## Behavior notes

This PR deliberately does not disable Credential Manager storage, delete persistent Windows Hello keys, or silently fall back to in-memory storage. A first worker pass tried that, but review rejected it as too broad for a possibly transient storage write failure. The final patch is warning-only: it preserves existing persistent-storage state and keeps the failure visible.

Refs #82

## Validation

- Worker subagent implemented the initial fix in an isolated branch.
- Reviewer subagent rejected the first version because it disabled persistent storage and could delete persistent auth material.
- Patch was trimmed to warning-only behavior.
- Reviewer subagent approved the trimmed version with no findings.
- `git diff --check` passed with only Git LF-to-CRLF working-copy warnings.
- `MSBuild.exe src\KeePassWinHello.csproj /t:Rebuild /p:Configuration=Release /p:DefineConstants=MONO /p:FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319 /p:ReferencePath=C:\proj\KeePassWinHello\lib` passed with 0 warnings and 0 errors.

## Manual test needed

- Elevated KeePass with persistent storage enabled, reproducing `CredWrite` 0x520, to confirm the warning appears instead of the generic report dialog.