### PR TITLE
[codex] Handle invalid-state persistent key deletion

### DIFF
--- a/src/AuthProviders/WinHelloProvider.cs
+++ b/src/AuthProviders/WinHelloProvider.cs
@@ -34,6 +34,7 @@ namespace KeePassWinHello
         private const int TPM_20_E_SIZE = unchecked((int)0x80280095);
         private const int TPM_20_E_159 = unchecked((int)0x80280159);
         private const int ERROR_CANCELLED = unchecked((int)0x800704C7);
+        private const int HRESULT_FROM_WIN32_ERROR_INVALID_STATE = unchecked((int)0x8007139F);
         private const int WINBIO_E_DATA_PROTECTION_FAILURE = unchecked((int)0x80098046); // The biometric service could not decrypt the data.
 
         [StructLayout(LayoutKind.Sequential)]
@@ -391,7 +392,12 @@ namespace KeePassWinHello
             {
                 using (ngcKeyHandle)
                 {
-                    NCryptDeleteKey(ngcKeyHandle, 0).ThrowOnError("NCryptDeleteKey");
+                    SECURITY_STATUS status = NCryptDeleteKey(ngcKeyHandle, 0);
+                    // Let callers finish revoking Credential Manager blobs when the NGC resource is already unusable.
+                    if (status.secStatus == HRESULT_FROM_WIN32_ERROR_INVALID_STATE)
+                        return;
+
+                    status.ThrowOnError("NCryptDeleteKey");
                     ngcKeyHandle.SetHandleAsInvalid();
                 }
             }

--- a/src/KeyManagement/KeyManagerProvider.cs
+++ b/src/KeyManagement/KeyManagerProvider.cs
@@ -86,9 +86,22 @@ namespace KeePassWinHello
                     throw;
 
                 Settings.Instance.WinStorageEnabled = false;
+                RevokePersistentKeys();
                 authCacheType = Settings.Instance.GetAuthCacheType();
                 _uiContextManager.CurrentContext.ShowError(ex, "For security reasons Credential Manager storage has been turned off. Use Options dialog to turn it on.");
                 return AuthProviderFactory.GetInstance(authCacheType, _uiContextManager);
+            }
+        }
+
+        private void RevokePersistentKeys()
+        {
+            try
+            {
+                new KeyWindowsStorage().Clear();
+            }
+            catch (Exception ex)
+            {
+                _uiContextManager.CurrentContext.ShowError(ex, "Persistent Credential Manager storage could not be cleared.");
             }
         }
     }


### PR DESCRIPTION
## What changed

- Treat `NCryptDeleteKey` `HRESULT_FROM_WIN32(ERROR_INVALID_STATE)` / `0x8007139F` as a tolerated delete-time state in `DeletePersistentKey`.
- Still throw for every other `NCryptDeleteKey` failure.
- When persistent key integrity fails during provider initialization, clear this plugin's Credential Manager blobs before returning to local cache mode.

## Why

Issue #87 reports `NCryptDeleteKey — ERROR_INVALID_STATE (0x8007139F)`. That status means Windows says the resource is not in the correct state for the requested operation. In this cleanup path, surfacing it as an unexpected system error can block the rest of the plugin's invalid-key recovery.

The key point is safety: ignoring this specific delete-time status could leave an orphaned Windows Hello/NGC key object, but the plugin also needs the encrypted database-key payload stored in Credential Manager to unlock a database. This PR clears the plugin's `KeePassWinHello_*` Credential Manager blobs when persistent key integrity fails, so a stranded NGC key alone is not useful for KeePassWinHello unlock.

Refs #87

## Behavior notes

- This does not ignore arbitrary deletion failures.
- This does not mark the failed NGC delete as successful; the handle is still disposed normally.
- Credential Manager cleanup is scoped to this plugin's own target prefix.

## Review notes

Reviewer found no blocking issues. One existing caveat remains: `KeyWindowsStorage.Clear()` currently ignores individual `CredDelete` failures while clearing plugin blobs. That behavior predates this PR and may deserve a separate hardening change, but expanding it here would broaden the fix.

## Validation

- Worker subagent implemented the narrow fix in an isolated branch.
- Reviewer subagent found no blocking issues and recommended publishing with the cleanup caveat noted.
- `git diff --check` passed with only Git LF-to-CRLF working-copy warnings.
- `MSBuild.exe src\KeePassWinHello.csproj /t:Rebuild /p:Configuration=Release /p:DefineConstants=MONO /p:FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319 /p:ReferencePath=C:\proj\KeePassWinHello\lib` passed with 0 warnings and 0 errors.

## Manual test needed

- Reproduce `NCryptDeleteKey` `0x8007139F` during persistent-key revocation or invalid-key recovery and confirm recovery continues without a generic report dialog.