### PR TITLE
[codex] Add per-database quick unlock selection

### DIFF
--- a/src/KeePassWinHelloExt.cs
+++ b/src/KeePassWinHelloExt.cs
@@ -119,7 +119,7 @@ namespace KeePassWinHello
                     var keyManager = _keyManagerProvider.ObtainKeyManager();
                     using (_uiContextManager.PushContext("Modifying KeePass settings", optionsForm))
                     {
-                        OptionsPanel.OnOptionsLoad(optionsForm, keyManager, _uiContextManager);
+                        OptionsPanel.OnOptionsLoad(optionsForm, _host, keyManager, _uiContextManager);
                         return;
                     }
                 }

--- a/src/KeyManagement/KeyManager.cs
+++ b/src/KeyManagement/KeyManager.cs
@@ -44,6 +44,10 @@ namespace KeePassWinHello
             if (!Settings.Instance.Enabled)
                 return;
 
+            string dbPath = GetDbPath(keyPromptForm);
+            if (!Settings.Instance.IsDatabaseEnabled(dbPath))
+                return;
+
             if (SystemInformation.TerminalServerSession) // RDP
             {
                 if (!_notifiedAboutRdp)
@@ -61,7 +65,6 @@ namespace KeePassWinHello
                 _notifiedAboutRdp = false;
             }
 
-            string dbPath = GetDbPath(keyPromptForm);
             if (keyPromptForm.SecureDesktopMode)
             {
                 if (IsKeyForDataBaseExist(dbPath))
@@ -135,7 +138,11 @@ namespace KeePassWinHello
             if (databaseMasterKey == null)
                 return;
 
-            Lock(IsDBLocking(e), e.Database.IOConnectionInfo.Path, databaseMasterKey);
+            string dbPath = e.Database.IOConnectionInfo.Path;
+            if (!Settings.Instance.IsDatabaseEnabled(dbPath))
+                return;
+
+            Lock(IsDBLocking(e), dbPath, databaseMasterKey);
         }
 
         private void StopMonitorWarning()

--- a/src/KeyManagement/Storage/KeyWindowsStorage.cs
+++ b/src/KeyManagement/Storage/KeyWindowsStorage.cs
@@ -69,7 +69,7 @@ namespace KeePassWinHello
             ForEach(ncred => credsToRemove.Add(Marshal.PtrToStringUni(ncred.TargetName)));
 
             foreach (var target in credsToRemove)
-                CredDelete(target, CRED_TYPE_GENERIC, 0);
+                CredDelete(target, CRED_TYPE_GENERIC, 0).ThrowOnError("CredDelete", ERROR_NOT_FOUND);
         }
 
         private string GetTarget(string path)

--- a/src/Settings/OptionsPanel.Designer.cs
+++ b/src/Settings/OptionsPanel.Designer.cs
@@ -41,6 +41,9 @@
             this.linkToGitHub = new System.Windows.Forms.LinkLabel();
             this.bottomPanel = new System.Windows.Forms.Panel();
             this.forceKeysRevokeToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.databaseSelectionPanel = new System.Windows.Forms.Panel();
+            this.databaseSelectionList = new System.Windows.Forms.CheckedListBox();
+            this.limitToSelectedDatabasesCheckBox = new System.Windows.Forms.CheckBox();
             this.winHelloDisabledPanel.SuspendLayout();
             this.invalidationPanel.SuspendLayout();
             this.storedKeysInfoPanel.SuspendLayout();
@@ -48,6 +51,7 @@
             this.keyCreatePanel.SuspendLayout();
             this.isNotElevatedPanel.SuspendLayout();
             this.bottomPanel.SuspendLayout();
+            this.databaseSelectionPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // winKeyStorageCheckBox
@@ -333,12 +337,47 @@
             this.bottomPanel.Name = "bottomPanel";
             this.bottomPanel.Size = new System.Drawing.Size(733, 22);
             this.bottomPanel.TabIndex = 54;
+            //
+            // databaseSelectionPanel
+            //
+            this.databaseSelectionPanel.Controls.Add(this.databaseSelectionList);
+            this.databaseSelectionPanel.Controls.Add(this.limitToSelectedDatabasesCheckBox);
+            this.databaseSelectionPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.databaseSelectionPanel.Location = new System.Drawing.Point(0, 179);
+            this.databaseSelectionPanel.Name = "databaseSelectionPanel";
+            this.databaseSelectionPanel.Padding = new System.Windows.Forms.Padding(7, 6, 5, 5);
+            this.databaseSelectionPanel.Size = new System.Drawing.Size(733, 132);
+            this.databaseSelectionPanel.TabIndex = 55;
+            //
+            // databaseSelectionList
+            //
+            this.databaseSelectionList.CheckOnClick = true;
+            this.databaseSelectionList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.databaseSelectionList.FormattingEnabled = true;
+            this.databaseSelectionList.IntegralHeight = false;
+            this.databaseSelectionList.Location = new System.Drawing.Point(7, 33);
+            this.databaseSelectionList.Name = "databaseSelectionList";
+            this.databaseSelectionList.Size = new System.Drawing.Size(721, 94);
+            this.databaseSelectionList.TabIndex = 7;
+            //
+            // limitToSelectedDatabasesCheckBox
+            //
+            this.limitToSelectedDatabasesCheckBox.AutoSize = true;
+            this.limitToSelectedDatabasesCheckBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.limitToSelectedDatabasesCheckBox.Location = new System.Drawing.Point(7, 6);
+            this.limitToSelectedDatabasesCheckBox.Name = "limitToSelectedDatabasesCheckBox";
+            this.limitToSelectedDatabasesCheckBox.Padding = new System.Windows.Forms.Padding(0, 0, 0, 6);
+            this.limitToSelectedDatabasesCheckBox.Size = new System.Drawing.Size(721, 27);
+            this.limitToSelectedDatabasesCheckBox.TabIndex = 6;
+            this.limitToSelectedDatabasesCheckBox.Text = "Use Windows Hello only for selected open databases";
+            this.limitToSelectedDatabasesCheckBox.UseVisualStyleBackColor = true;
             // 
             // OptionsPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.bottomPanel);
+            this.Controls.Add(this.databaseSelectionPanel);
             this.Controls.Add(this.invalidationPanel);
             this.Controls.Add(this.persistentStoragePanel);
             this.Controls.Add(this.revokeOnCancel);
@@ -360,6 +399,8 @@
             this.isNotElevatedPanel.PerformLayout();
             this.bottomPanel.ResumeLayout(false);
             this.bottomPanel.PerformLayout();
+            this.databaseSelectionPanel.ResumeLayout(false);
+            this.databaseSelectionPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -389,5 +430,8 @@
         private System.Windows.Forms.LinkLabel linkToGitHub;
         private System.Windows.Forms.Panel bottomPanel;
         private System.Windows.Forms.ToolTip forceKeysRevokeToolTip;
+        private System.Windows.Forms.Panel databaseSelectionPanel;
+        private System.Windows.Forms.CheckedListBox databaseSelectionList;
+        private System.Windows.Forms.CheckBox limitToSelectedDatabasesCheckBox;
     }
 }

--- a/src/Settings/OptionsPanel.cs
+++ b/src/Settings/OptionsPanel.cs
@@ -15,6 +15,25 @@ namespace KeePassWinHello
         private bool _initialized;
         private bool _wasKeyRemovingIntendedByUser;
 
+        internal sealed class DatabaseItem
+        {
+            public string Path { get; private set; }
+            public string DisplayName { get; private set; }
+
+            public DatabaseItem(string path, string displayName)
+            {
+                Path = path;
+                DisplayName = displayName;
+            }
+
+            public override string ToString()
+            {
+                return DisplayName;
+            }
+        }
+
+        private readonly IList<DatabaseItem> _databaseItems;
+
         private bool IsSettingsEnabled
         {
             get
@@ -33,12 +52,13 @@ namespace KeePassWinHello
             get { return _keyManager != null; }
         }
 
-        private OptionsPanel(IKeyManager keyManager, UIContextManager uiContextManager)
+        private OptionsPanel(IKeyManager keyManager, UIContextManager uiContextManager, IList<DatabaseItem> databaseItems)
         {
             InitializeComponent();
 
             _keyManager = keyManager;
             _uiContextManager = uiContextManager;
+            _databaseItems = databaseItems ?? new List<DatabaseItem>();
             uacIcoPanel.Paint += OnPaint_ElevatedIconPanel;
             keyCreateIcoPanel.Paint += OnPaint_KeyCreateIconPanel;
         }
@@ -72,14 +92,26 @@ namespace KeePassWinHello
         {
             isEnabledCheckBox.CheckedChanged -= IsEnabledCheckBox_CheckedChanged;
             winKeyStorageCheckBox.CheckedChanged -= WinKeyStorageCheckBox_CheckedChanged;
+            limitToSelectedDatabasesCheckBox.CheckedChanged -= LimitToSelectedDatabasesCheckBox_CheckedChanged;
+            databaseSelectionList.ItemCheck -= DatabaseSelectionList_ItemCheck;
 
             isEnabledCheckBox.Checked = Settings.Instance.Enabled;
             revokeOnCancel.Checked = Settings.Instance.RevokeOnCancel;
             winKeyStorageCheckBox.Checked = Settings.Instance.WinStorageEnabled;
             validPeriodComboBox.SelectedIndex = PeriodToIndex(Settings.Instance.InvalidatingTime);
+            limitToSelectedDatabasesCheckBox.Checked = Settings.Instance.LimitToSelectedDatabases;
+
+            databaseSelectionList.Items.Clear();
+            foreach (DatabaseItem databaseItem in _databaseItems)
+            {
+                databaseSelectionList.Items.Add(databaseItem,
+                    Settings.Instance.IsDatabaseSelected(databaseItem.Path));
+            }
 
             isEnabledCheckBox.CheckedChanged += IsEnabledCheckBox_CheckedChanged;
             winKeyStorageCheckBox.CheckedChanged += WinKeyStorageCheckBox_CheckedChanged;
+            limitToSelectedDatabasesCheckBox.CheckedChanged += LimitToSelectedDatabasesCheckBox_CheckedChanged;
+            databaseSelectionList.ItemCheck += DatabaseSelectionList_ItemCheck;
         }
 
         private void OnClosing(object sender, FormClosingEventArgs e)
@@ -87,7 +119,11 @@ namespace KeePassWinHello
             if (ParentForm.DialogResult == DialogResult.OK)
             {
                 Settings settings = Settings.Instance;
-                SaveSettings(settings);
+                if (!SaveSettings(settings))
+                {
+                    e.Cancel = true;
+                    return;
+                }
             }
             ParentForm.FormClosing -= OnClosing;
         }
@@ -103,18 +139,33 @@ namespace KeePassWinHello
             UpdateStoredKeysPanel();
         }
 
+        private void LimitToSelectedDatabasesCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            ProcessControlsVisibility();
+        }
+
+        private void DatabaseSelectionList_ItemCheck(object sender, ItemCheckEventArgs e)
+        {
+            BeginInvoke(new MethodInvoker(UpdateStoredKeysPanel));
+        }
+
         private void RevokeAll_CheckedChanged(object sender, EventArgs e)
         {
             _wasKeyRemovingIntendedByUser = revokeAllCheckBox.Checked;
             UpdateStoredKeysPanel();
         }
 
-        private void SaveSettings(Settings settings)
+        private bool SaveSettings(Settings settings)
         {
+            bool databasePolicyChanged = IsDatabasePolicyChanged();
+            if ((revokeAllCheckBox.Checked || databasePolicyChanged) && !RevokeAllKeys())
+                return false;
+
             settings.Enabled = isEnabledCheckBox.Checked;
 
-            if (revokeAllCheckBox.Checked)
-                RevokeAllKeys();
+            if (databasePolicyChanged)
+                settings.SetSelectedDatabases(GetSelectedDatabasePaths(), GetDisplayedDatabasePaths());
+            settings.LimitToSelectedDatabases = limitToSelectedDatabasesCheckBox.Checked;
 
             if (isEnabledCheckBox.Checked)
             {
@@ -135,7 +186,7 @@ namespace KeePassWinHello
                                 MessageBox.Show(_uiContextManager.CurrentContext,
                                     "Changing storage location setting on a remote session is not permitted",
                                     Settings.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Information);
-                                return;
+                                return true;
                             }
 
                             try
@@ -160,6 +211,8 @@ namespace KeePassWinHello
                     }
                 }
             }
+
+            return true;
         }
 
         private void TryClaimLocalCacheType()
@@ -183,6 +236,9 @@ namespace KeePassWinHello
             validPeriodComboBox.Enabled = isEnabled;
             revokeOnCancel.Enabled = isEnabled;
             winKeyStorageCheckBox.Enabled = isEnabled;
+
+            limitToSelectedDatabasesCheckBox.Enabled = isEnabled;
+            databaseSelectionList.Enabled = isEnabled && limitToSelectedDatabasesCheckBox.Checked;
 
             keyCreatePanel.Visible = isEnabled
                                  && winKeyStorageCheckBox.Checked
@@ -212,7 +268,8 @@ namespace KeePassWinHello
 
             bool intendedToDisablePlugin = !isEnabledCheckBox.Checked && Settings.Instance.Enabled;
             bool intendedToChangeStorage = winKeyStorageCheckBox.Checked != Settings.Instance.WinStorageEnabled;
-            bool shouldRemoveKeys = intendedToDisablePlugin || intendedToChangeStorage;
+            bool intendedToChangeDatabasePolicy = IsDatabasePolicyChanged();
+            bool shouldRemoveKeys = intendedToDisablePlugin || intendedToChangeStorage || intendedToChangeDatabasePolicy;
 
             storedKeysInfoPanel.Visible = isAvailable;
             revokeAllCheckBox.Enabled = savedKeysExists && !shouldRemoveKeys;
@@ -250,24 +307,65 @@ namespace KeePassWinHello
                     toolTipMsg = "The keys cannot be stored while the plugin is disabled";
                 else if (intendedToChangeStorage)
                     toolTipMsg = "The keys cannot be transferred between the in-memory storage and the persistent one";
+                else if (intendedToChangeDatabasePolicy)
+                    toolTipMsg = "Stored keys are revoked when the database selection changes";
             }
             forceKeysRevokeToolTip.SetToolTip(storedKeysCountLabel, toolTipMsg);
         }
 
-        private void RevokeAllKeys()
+        private bool IsDatabasePolicyChanged()
         {
-            if (_keyManager != null)
+            if (limitToSelectedDatabasesCheckBox.Checked != Settings.Instance.LimitToSelectedDatabases)
+                return true;
+
+            for (int i = 0; i < databaseSelectionList.Items.Count; ++i)
             {
-                try
-                {
-                    _keyManager.RevokeAll();
-                }
-                catch (Exception ex)
-                {
-                    _uiContextManager.CurrentContext.ShowError(ex);
-                }
+                var databaseItem = databaseSelectionList.Items[i] as DatabaseItem;
+                if (databaseItem != null && databaseSelectionList.GetItemChecked(i) !=
+                    Settings.Instance.IsDatabaseSelected(databaseItem.Path))
+                    return true;
             }
-            UpdateStoredKeysPanel();
+
+            return false;
+        }
+
+        private IEnumerable<string> GetSelectedDatabasePaths()
+        {
+            foreach (object item in databaseSelectionList.CheckedItems)
+            {
+                var databaseItem = item as DatabaseItem;
+                if (databaseItem != null)
+                    yield return databaseItem.Path;
+            }
+        }
+
+        private IEnumerable<string> GetDisplayedDatabasePaths()
+        {
+            foreach (object item in databaseSelectionList.Items)
+            {
+                var databaseItem = item as DatabaseItem;
+                if (databaseItem != null)
+                    yield return databaseItem.Path;
+            }
+        }
+
+        private bool RevokeAllKeys()
+        {
+            if (_keyManager == null)
+                return true;
+
+            try
+            {
+                _keyManager.RevokeAll();
+                UpdateStoredKeysPanel();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _uiContextManager.CurrentContext.ShowError(ex,
+                    "Stored database keys could not be revoked. Database selection changes were not saved.");
+                return false;
+            }
         }
 
         private void linkToGitHub_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/src/Settings/OptionsPanelCreation.cs
+++ b/src/Settings/OptionsPanelCreation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -7,17 +8,20 @@ using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
 using KeePass.Forms;
+using KeePass.Plugins;
+using KeePassLib;
+using KeePassLib.Serialization;
 
 namespace KeePassWinHello
 {
     partial class OptionsPanel
     {
-        internal static void OnOptionsLoad(OptionsForm optionsForm, IKeyManager keyManager, UIContextManager uiContextManager)
+        internal static void OnOptionsLoad(OptionsForm optionsForm, IPluginHost host, IKeyManager keyManager, UIContextManager uiContextManager)
         {
-            AddTab(GetTabControl(optionsForm), GetTabsImageList(optionsForm), keyManager, uiContextManager);
+            AddTab(GetTabControl(optionsForm), GetTabsImageList(optionsForm), keyManager, uiContextManager, GetDatabaseItems(host));
         }
 
-        private static void AddTab(TabControl tabMain, ImageList imageList, IKeyManager keyManager, UIContextManager uiContextManager)
+        private static void AddTab(TabControl tabMain, ImageList imageList, IKeyManager keyManager, UIContextManager uiContextManager, IList<DatabaseItem> databaseItems)
         {
             Debug.Assert(tabMain != null);
             if (tabMain == null)
@@ -37,7 +41,7 @@ namespace KeePassWinHello
 
             const string iconKey = "KPWH_icon";
             imageList.Images.Add(iconKey, Properties.Resources.KPWH);
-            var optionsPanel = new OptionsPanel(keyManager, uiContextManager);
+            var optionsPanel = new OptionsPanel(keyManager, uiContextManager, databaseItems);
 
             var newTab = new TabPage(Settings.OptionsTabName)
             {
@@ -63,6 +67,98 @@ namespace KeePassWinHello
             if (m_ilIconsField == null)
                 return null;
             return m_ilIconsField.GetValue(optionsForm) as ImageList;
+        }
+
+        private static IList<DatabaseItem> GetDatabaseItems(IPluginHost host)
+        {
+            var result = new List<DatabaseItem>();
+            var paths = new HashSet<string>(StringComparer.Ordinal);
+
+            if (host == null)
+                return result;
+
+            try
+            {
+                PropertyInfo documentManagerProperty = host.MainWindow.GetType().GetProperty("DocumentManager");
+                object documentManager = documentManagerProperty != null
+                    ? documentManagerProperty.GetValue(host.MainWindow, null)
+                    : null;
+                PropertyInfo documentsProperty = documentManager != null
+                    ? documentManager.GetType().GetProperty("Documents")
+                    : null;
+                var documents = documentsProperty != null
+                    ? documentsProperty.GetValue(documentManager, null) as IEnumerable
+                    : null;
+
+                if (documents != null)
+                {
+                    foreach (object document in documents)
+                    {
+                        try
+                        {
+                            AddDatabaseItem(result, paths, GetDocumentConnectionInfo(document));
+                        }
+                        catch (Exception)
+                        {
+                            // Ignore one incompatible document and continue discovering the others.
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Fall back to the active database below for KeePass versions with different internals.
+            }
+
+            if (host.Database != null)
+                AddDatabaseItem(result, paths, host.Database.IOConnectionInfo);
+
+            return result;
+        }
+
+        private static IOConnectionInfo GetDocumentConnectionInfo(object document)
+        {
+            if (document == null)
+                return null;
+
+            PropertyInfo databaseProperty = document.GetType().GetProperty("Database");
+            var database = databaseProperty != null
+                ? databaseProperty.GetValue(document, null) as PwDatabase
+                : null;
+            if (database != null && database.IOConnectionInfo != null &&
+                !String.IsNullOrEmpty(database.IOConnectionInfo.Path))
+                return database.IOConnectionInfo;
+
+            PropertyInfo lockedIocProperty = document.GetType().GetProperty("LockedIoc");
+            return lockedIocProperty != null
+                ? lockedIocProperty.GetValue(document, null) as IOConnectionInfo
+                : null;
+        }
+
+        private static void AddDatabaseItem(ICollection<DatabaseItem> result,
+            ISet<string> paths, IOConnectionInfo connectionInfo)
+        {
+            if (connectionInfo == null || String.IsNullOrEmpty(connectionInfo.Path) ||
+                !paths.Add(connectionInfo.Path))
+                return;
+
+            string displayName;
+            try
+            {
+                MethodInfo getDisplayNameMethod = connectionInfo.GetType().GetMethod("GetDisplayName", Type.EmptyTypes);
+                displayName = getDisplayNameMethod != null
+                    ? getDisplayNameMethod.Invoke(connectionInfo, null) as string
+                    : null;
+            }
+            catch (Exception)
+            {
+                displayName = null;
+            }
+
+            if (String.IsNullOrEmpty(displayName))
+                displayName = connectionInfo.Path;
+
+            result.Add(new DatabaseItem(connectionInfo.Path, displayName));
         }
     }
 }

--- a/src/Settings/Settings.cs
+++ b/src/Settings/Settings.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
 using KeePass.App.Configuration;
 using KeePassWinHello.Utilities;
 
@@ -14,6 +17,8 @@ namespace KeePassWinHello
         private const string CFG_ENABLED = "WindowsHello.QuickUnlock.Enabled";
         private const string CFG_WINSTORAGE_ENABLED = "WindowsHello.QuickUnlock.WindowsStorage.Enabled";
         private const string CFG_REVOKE_ON_CANCEL = "WindowsHello.QuickUnlock.RevokeOnCancel";
+        private const string CFG_LIMIT_TO_SELECTED_DATABASES = "WindowsHello.QuickUnlock.LimitToSelectedDatabases";
+        private const string CFG_SELECTED_DATABASES = "WindowsHello.QuickUnlock.SelectedDatabases";
         private const string CFG_SAVED_SETTINGS_PLUGIN_VERSION = "WindowsHello.QuickUnlock.SavedSettingsPluginVersion";
         private const string DEPRECATED_CFG_AUTO_PROMPT = "WindowsHello_AutoPrompt";
 
@@ -138,6 +143,78 @@ namespace KeePassWinHello
             {
                 _customConfig.SetBool(CFG_REVOKE_ON_CANCEL, value);
             }
+        }
+
+        public bool LimitToSelectedDatabases
+        {
+            get
+            {
+                return _customConfig.GetBool(CFG_LIMIT_TO_SELECTED_DATABASES, false);
+            }
+            set
+            {
+                _customConfig.SetBool(CFG_LIMIT_TO_SELECTED_DATABASES, value);
+            }
+        }
+
+        public bool IsDatabaseEnabled(string dbPath)
+        {
+            if (!LimitToSelectedDatabases)
+                return true;
+
+            return IsDatabaseSelected(dbPath);
+        }
+
+        public bool IsDatabaseSelected(string dbPath)
+        {
+            if (String.IsNullOrEmpty(dbPath))
+                return false;
+
+            return GetSelectedDatabaseIds().Contains(GetDatabaseId(dbPath));
+        }
+
+        public void SetSelectedDatabases(IEnumerable<string> selectedPaths, IEnumerable<string> displayedPaths)
+        {
+            if (selectedPaths == null)
+                throw new ArgumentNullException("selectedPaths");
+            if (displayedPaths == null)
+                throw new ArgumentNullException("displayedPaths");
+
+            var selectedIds = GetSelectedDatabaseIds();
+            foreach (string path in displayedPaths)
+            {
+                if (!String.IsNullOrEmpty(path))
+                    selectedIds.Remove(GetDatabaseId(path));
+            }
+
+            foreach (string path in selectedPaths)
+            {
+                if (!String.IsNullOrEmpty(path))
+                    selectedIds.Add(GetDatabaseId(path));
+            }
+
+            var values = new List<string>(selectedIds);
+            values.Sort(StringComparer.Ordinal);
+            _customConfig.SetString(CFG_SELECTED_DATABASES, String.Join(";", values.ToArray()));
+        }
+
+        private HashSet<string> GetSelectedDatabaseIds()
+        {
+            var result = new HashSet<string>(StringComparer.Ordinal);
+            string value = _customConfig.GetString(CFG_SELECTED_DATABASES, String.Empty);
+            string[] databaseIds = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string databaseId in databaseIds)
+                result.Add(databaseId);
+            return result;
+        }
+
+        private static string GetDatabaseId(string dbPath)
+        {
+            byte[] pathBytes = Encoding.UTF8.GetBytes(dbPath);
+            byte[] hash;
+            using (SHA256 sha256 = SHA256.Create())
+                hash = sha256.ComputeHash(pathBytes);
+            return Convert.ToBase64String(hash);
         }
 
         public const long VALID_PERIOD_DEFAULT = 1000 * 60 * 60 * 24; // one day in ms


### PR DESCRIPTION
## What changed

- Added an opt-in `Use Windows Hello only for selected open databases` mode to the plugin options.
- Added a checked list of currently open or locked KeePass databases.
- Gated Windows Hello unlock and key caching by the selected database connection location.
- Preserved existing behavior by default: when the new option is disabled, all databases remain eligible as before.
- Stored selected connection locations as SHA-256 identifiers in KeePass custom configuration rather than storing plaintext paths in the new setting.
- Revoked all cached database keys when the database-selection policy changes.
- Made persistent revocation strict: individual `CredDelete` failures now propagate, except when the credential is already absent.
- If revocation fails, no selection settings are written and the Options dialog remains open.
- Kept Cancel behavior side-effect free.

## Why

Issue #91 asks for biometric quick unlock to be enabled only for selected databases. The plugin previously had one global enable switch and cached every eligible database key after normal unlock.

This implementation adds an explicit opt-in allowlist while preserving the current default for existing users. Enforcement happens both before Windows Hello unlock and before caching a key, including the secure-desktop restart path.

## Database identity

KeePassWinHello must decide whether a database is selected before that database is unlocked. A stable internal database UUID is therefore unavailable at the decision point. The implementation uses the exact KeePass connection path/location, hashed before storing it in the new config value.

This is intentionally fail-closed:

- Moving or renaming a database requires selecting it again.
- Equivalent paths with different casing or aliases may require selecting again.
- A remembered selection represents a connection location, not intrinsic database identity.
- Selections for databases that are not currently open/locked remain remembered and are not currently removable individually from this UI.

The existing Credential Manager storage remains path-based and is unchanged.

## Security and revocation behavior

Changing the selection policy revokes all cached keys, including persistent Credential Manager entries. This is conservative but prevents deselected databases from retaining usable cached material.

A worker review found that the first implementation could save the new policy after a silent credential-deletion failure. The final implementation checks each deletion, performs revocation before writing settings, and cancels Options closing if revocation fails.

This security/revocation behavior was explicitly approved before publication.

Refs #91

## Validation

- Worker subagent implemented the feature in an isolated branch.
- Reviewer subagent performed three review passes.
- Addressed blocking revocation failure handling and per-document reflection isolation.
- Final review found no blocking issues and recommended a draft PR.
- `git diff --check` passed with only Git LF-to-CRLF working-copy warnings.
- `MSBuild.exe src\KeePassWinHello.csproj /t:Rebuild /p:Configuration=Release /p:DefineConstants=MONO /p:FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319 /p:ReferencePath=C:\proj\KeePassWinHello\lib` passed with 0 warnings and 0 errors.

## Manual test required

- Options OK versus Cancel.
- Enabling/disabling selected-only mode.
- Selecting and deselecting open and locked database tabs.
- Local and persistent cache modes.
- Failed Credential Manager deletion while applying policy.
- Secure desktop enabled/disabled.
- RDP behavior.
- Database path casing, rename, move, and URL connection paths.