### PR TITLE
[codex] Handle invalid cached wrapping keys

### DIFF
--- a/src/Exceptions/InvalidProtectedKeyException.cs
+++ b/src/Exceptions/InvalidProtectedKeyException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace KeePassWinHello
+{
+    [Serializable]
+    public class InvalidProtectedKeyException : KeePassWinHelloException
+    {
+        public override bool IsPresentable { get { return true; } }
+
+        public InvalidProtectedKeyException()
+            : this("The cached key for this database is invalid and has been removed.") { }
+        public InvalidProtectedKeyException(string message) : base(message) { }
+        public InvalidProtectedKeyException(string message, Exception inner) : base(message, inner) { }
+        protected InvalidProtectedKeyException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/KeePassWinHello.csproj
+++ b/src/KeePassWinHello.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Exceptions\AuthProviderKeyNotFoundException.cs" />
+    <Compile Include="Exceptions\InvalidProtectedKeyException.cs" />
     <Compile Include="KeyManagement\KeyManagerProvider.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/KeyManagement/KeyCipher.cs
+++ b/src/KeyManagement/KeyCipher.cs
@@ -49,6 +49,8 @@ namespace KeePassWinHello
             try
             {
                 data = _cryptProvider.PromptToDecrypt(encryptedData);
+                if (data == null || data.Length != (int)(_randomSeedBits >> 3))
+                    throw new InvalidProtectedKeyException();
 
                 var result = new ProtectedBinary(true, data);
                 return result;

--- a/src/KeyManagement/KeyManager.cs
+++ b/src/KeyManagement/KeyManager.cs
@@ -70,8 +70,8 @@ namespace KeePassWinHello
             else
             {
                 StopMonitorWarning();
-                RestoreSecureDesktopSettings();
-                Unlock(keyPromptForm, dbPath);
+                bool restartedFromSecureDesktop = RestoreSecureDesktopSettings();
+                Unlock(keyPromptForm, dbPath, restartedFromSecureDesktop);
             }
         }
 
@@ -107,14 +107,16 @@ namespace KeePassWinHello
             CloseFormWithResult(keyPromptForm, DialogResult.OK);
         }
 
-        private void RestoreSecureDesktopSettings()
+        private bool RestoreSecureDesktopSettings()
         {
             int oldTriesValue = Interlocked.Exchange(ref _masterKeyTries, NoChanges);
             if (oldTriesValue != NoChanges)
             {
                 KeePass.Program.Config.Security.MasterKeyTries = oldTriesValue;
                 KeePass.Program.Config.Security.MasterKeyOnSecureDesktop = true;
+                return true;
             }
+            return false;
         }
 
         public void OnDBClosing(object sender, FileClosingEventArgs e)
@@ -144,7 +146,7 @@ namespace KeePassWinHello
                 _warningSuppresser = null;
         }
 
-        private void Unlock(KeyPromptForm keyPromptForm, string dbPath)
+        private void Unlock(KeyPromptForm keyPromptForm, string dbPath, bool restartedFromSecureDesktop)
         {
             try
             {
@@ -153,6 +155,20 @@ namespace KeePassWinHello
                 {
                     SetCompositeKey(keyPromptForm, compositeKey);
                     CloseFormWithResult(keyPromptForm, DialogResult.OK);
+                }
+            }
+            catch (InvalidProtectedKeyException ex)
+            {
+                if (restartedFromSecureDesktop)
+                {
+                    _uiContextManager.CurrentContext.ShowError(ex,
+                        "Quick unlock was canceled to preserve KeePass secure desktop. Start unlocking again to enter the database master key.");
+                    CloseFormWithResult(keyPromptForm, DialogResult.Cancel);
+                }
+                else
+                {
+                    _uiContextManager.CurrentContext.ShowError(ex,
+                        "Enter the database master key to continue.");
                 }
             }
             catch (AuthProviderKeyNotFoundException ex)
@@ -255,6 +271,11 @@ namespace KeePassWinHello
                     compositeKey = encryptedData.GetCompositeKey(_keyCipher);
                     return true;
                 }
+            }
+            catch (InvalidProtectedKeyException)
+            {
+                _keyStorage.Remove(dbPath);
+                throw;
             }
             catch (AuthProviderInvalidKeyException)
             {


### PR DESCRIPTION
## What changed

- Validate that Windows Hello decrypts the cached wrapping key to exactly 32 bytes before passing it to KeePass AES.
- Add a presentable `InvalidProtectedKeyException` for malformed cached wrapping-key material.
- Remove only the affected database's cached key when this validation fails.
- Keep the Windows Hello provider and other database caches intact.
- Leave the normal KeePass master-key prompt available on the normal desktop.
- Preserve secure desktop: if quick unlock had redirected the prompt to the main desktop, cancel that temporary prompt and require the user to start unlock again so password entry returns to secure desktop.
- Add the new exception source file to the legacy/PLGX project.

## Why

Issue #98 reports a long Windows Hello unlock followed by an abort. The maintainer noted that the screenshot error is thrown when `pbKey != 32`.

KeePassWinHello generates a 256-bit (32-byte) random wrapping password and protects it with Windows Hello. A valid cached entry created by this plugin must therefore decrypt to exactly 32 bytes. Any other length is corrupt, tampered, or foreign cached material; it must not be padded, truncated, or passed to the AES engine.

Previously the invalid length reached KeePass's AES validation and produced a low-level `ArgumentOutOfRangeException` for `pbKey`. The generic cleanup path removed the cache entry, but the user saw a confusing internal error. The new path validates earlier, reports the actual recovery action, and keeps normal authentication available.

## Security behavior

- Invalid plaintext is zeroed in the existing `finally` path.
- Only the affected database cache entry is removed.
- Existing provider-integrity failures still use the broader invalid-provider-key revocation path.
- Windows Hello retry/cancellation behavior is unchanged.
- Secure-desktop users are never instructed to enter the master key into the temporary non-secure prompt.

Refs #98

## Validation

- Worker subagent implemented the narrow validation and recovery path.
- First reviewer pass found a secure-desktop downgrade in recovery and requested changes.
- Recovery now tracks secure-desktop redirection and cancels the temporary main-desktop prompt.
- Second reviewer pass found no issues and recommended a draft PR.
- `git diff --check` passed with only Git LF-to-CRLF working-copy warnings.
- `MSBuild.exe src\KeePassWinHello.csproj /t:Rebuild /p:Configuration=Release /p:DefineConstants=MONO /p:FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319 /p:ReferencePath=C:\proj\KeePassWinHello\lib` passed with 0 warnings and 0 errors.

## Manual test required

- Corrupt/malformed cached wrapping key in local storage.
- Corrupt/malformed cached wrapping key in Credential Manager storage.
- Normal desktop recovery leaves the password prompt usable.
- Secure desktop recovery cancels the temporary prompt and returns to secure desktop on retry.