### PR TITLE
[codex] Document KeePass plugin cache recovery

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -53,6 +53,10 @@ Or you can use [Chocolatey](https://chocolatey.org/packages/keepass-plugin-winhe
 choco install keepass-plugin-winhello
 ```
 
+If the plugin disappears from `Tools` > `Plugins` after upgrading KeePass,
+open `Tools` > `Plugins`, click `Clear` under `Plugin Cache`, exit KeePass
+completely (including the tray icon), and start it again.
+
 Key storage
 -----------
 


### PR DESCRIPTION
## What changed

Added a short installation troubleshooting note explaining how to clear KeePass's plugin cache and fully restart KeePass when KeePassWinHello disappears from `Tools` > `Plugins` after a KeePass upgrade.

The instructions use the actual KeePass UI: open `Tools` > `Plugins`, click `Clear` under `Plugin Cache`, fully exit KeePass including its tray icon, and restart it.

## Why

Issue #110 initially looked like a KeePass 2.57/2.57.1 compatibility regression, but multiple users confirmed KeePassWinHello 3.3.1 works on those versions. One affected installation recovered after clearing KeePass's plugin cache and completely restarting KeePass.

The evidence points to stale KeePass plugin-cache state rather than an incompatible KeePassWinHello binary. Because KeePassWinHello code cannot run when KeePass does not load the plugin, runtime handling cannot reach this failure mode. Documenting the proven host-level recovery is the smallest honest fix and avoids encouraging an unnecessary downgrade to 3.2.

## User impact

Users who lose the plugin after a KeePass upgrade now have the recovery steps next to the installation instructions. The Plugins dialog and its cache controls are provided by KeePass, so the recovery remains available when KeePassWinHello itself is not loaded.

The minimized-window behavior discussed later in #110 is separate issue #107 and is addressed by PR #141; this PR does not mix that runtime behavior into the cache-loading fix.

## Review and validation

- Independent review verified that KeePass exposes a `Clear` button under the `Plugin Cache` section and that the dialog remains reachable when this plugin is absent.
- `git diff --check`
- Confirmed the branch is based on current `origin/master`.
- Reviewed the Markdown placement under `How to Install`.

No build was run because this changes documentation only. The cache failure was not reproduced locally; the recovery sequence is based on the successful confirmation in #110. The exact control label was independently checked against KeePass 2.61.1; the issue discussion describes the equivalent cache clearing flow on KeePass 2.57/2.57.1.

Closes #110