### PR TITLE
[codex] Document undocumented Passport properties

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -101,6 +101,10 @@ Create junction/copy folder with KeePass.exe to root of the repository as folder
 Debug "KeePassWinHello.Debug" project with "Linked KeePass" launch profile.
 If you add some file - don't forget to add it to `KeePassWinHello.csproj`, otherwise it won't be included in plgx on publish.
 
+### Undocumented provider properties
+
+The persistent Windows Hello key implementation first tries the Microsoft Passport provider-specific property name `NgcCacheType`, then falls back to `NgcCacheTypeProperty` if that operation fails. Neither name is publicly documented by Microsoft. Repository history records when the names were introduced, but not how they were discovered; do not treat this implementation as evidence that Microsoft supports either name as a stable API.
+
 Credits
 -------
 

--- a/src/AuthProviders/WinHelloProvider.cs
+++ b/src/AuthProviders/WinHelloProvider.cs
@@ -16,8 +16,10 @@ namespace KeePassWinHello
         private const string NCRYPT_USE_CONTEXT_PROPERTY = "Use Context";
         private const string NCRYPT_LENGTH_PROPERTY = "Length";
         private const string NCRYPT_KEY_USAGE_PROPERTY = "Key Usage";
+        // These Passport KSP-specific property names are not publicly documented by Microsoft.
+        // Keep the second spelling as a fallback, but do not assume either is a stable API.
         private const string NCRYPT_NGC_CACHE_TYPE_PROPERTY = "NgcCacheType";
-        private const string NCRYPT_NGC_CACHE_TYPE_PROPERTY_DEPRECATED = "NgcCacheTypeProperty";
+        private const string NCRYPT_NGC_CACHE_TYPE_PROPERTY_FALLBACK = "NgcCacheTypeProperty";
         private const string NCRYPT_PIN_CACHE_IS_GESTURE_REQUIRED_PROPERTY = "PinCacheIsGestureRequired";
         private const string BCRYPT_RSA_ALGORITHM = "RSA";
         private const int NCRYPT_NGC_CACHE_TYPE_PROPERTY_AUTH_MANDATORY_FLAG = 0x00000001;
@@ -429,7 +431,7 @@ namespace KeePassWinHello
             }
             catch
             {
-                NCryptGetProperty(ngcKeyHandle, NCRYPT_NGC_CACHE_TYPE_PROPERTY_DEPRECATED, ref cacheType, sizeof(int), out pcbResult, CngPropertyOptions.None).ThrowOnError("NCRYPT_NGC_CACHE_TYPE_PROPERTY_DEPRECATED");
+                NCryptGetProperty(ngcKeyHandle, NCRYPT_NGC_CACHE_TYPE_PROPERTY_FALLBACK, ref cacheType, sizeof(int), out pcbResult, CngPropertyOptions.None).ThrowOnError("NCRYPT_NGC_CACHE_TYPE_PROPERTY_FALLBACK");
             }
             if (cacheType != NCRYPT_NGC_CACHE_TYPE_PROPERTY_AUTH_MANDATORY_FLAG)
                 return false;
@@ -466,7 +468,7 @@ namespace KeePassWinHello
                 }
                 catch
                 {
-                    NCryptSetProperty(ngcKeyHandle, NCRYPT_NGC_CACHE_TYPE_PROPERTY_DEPRECATED, cacheType, cacheType.Length, CngPropertyOptions.None).ThrowOnError("NCRYPT_NGC_CACHE_TYPE_PROPERTY_DEPRECATED");
+                    NCryptSetProperty(ngcKeyHandle, NCRYPT_NGC_CACHE_TYPE_PROPERTY_FALLBACK, cacheType, cacheType.Length, CngPropertyOptions.None).ThrowOnError("NCRYPT_NGC_CACHE_TYPE_PROPERTY_FALLBACK");
                 }
 
                 ApplyUIContext(ngcKeyHandle);


### PR DESCRIPTION
## What changed

- Added a Development note explaining that the persistent Windows Hello implementation first uses `NgcCacheType` and falls back to `NgcCacheTypeProperty`.
- Documented that neither Passport KSP-specific property name is publicly documented by Microsoft and must not be assumed to be a stable API.
- Added a nearby source comment so maintainers see the compatibility risk before modifying the NCrypt property handling.
- Renamed the internal `..._DEPRECATED` constant to `..._FALLBACK`; the repository only proves fallback order, not official deprecation.

## Why

Issue #112 asks where `NgcCacheType` came from and whether its use is based on public documentation, binary inspection, experimentation, private Microsoft guidance, or direct contact.

Repository history can establish when the names entered the project but not how they were discovered:

- commit `dd0022dd` introduced `NgcCacheType` during the persistent-key implementation;
- commit `e4630992` added `NgcCacheTypeProperty` as the second spelling tried when the first operation fails;
- neither commit nor the associated repository discussion records the discovery source or cites Microsoft guidance.

Microsoft documents that NCrypt providers may accept custom property identifiers, but these two identifiers do not appear in Microsoft's public property-identifier documentation. The project therefore cannot honestly claim official support, official deprecation, or known Windows-version compatibility. Preserving that uncertainty in the repository is safer for maintainers and downstream implementers than leaving the source looking like a documented API example.

## Behavior and compatibility

Runtime behavior is unchanged. The provider still tries `NgcCacheType` first and `NgcCacheTypeProperty` only if the first get/set operation throws. The code remains C# 5 and .NET Framework 4.0 compatible.

## Review

An independent review caught two overstatements in the initial patch:

- absence from the public identifier list does not put custom properties outside the NCrypt API contract;
- repository history does not prove that the fallback name is officially deprecated or tied to specific Windows versions.

The final wording now says only what the public documentation, source, and history establish. The follow-up review found no remaining actionable issues.

## Validation

- Release/MONO rebuild of `src/KeePassWinHello.csproj`
- `FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319`
- `ReferencePath=C:\proj\KeePassWinHello\lib`
- 0 warnings, 0 errors
- `git diff --check`

No Windows Hello or Credential Manager keys were created, deleted, or changed during validation.

Closes #112