### PR TITLE
[codex] Retry expired Windows Hello biometric tickets

### DIFF
--- a/src/AuthProviders/WinHelloProvider.cs
+++ b/src/AuthProviders/WinHelloProvider.cs
@@ -34,6 +34,7 @@ namespace KeePassWinHello
         private const int TPM_20_E_SIZE = unchecked((int)0x80280095);
         private const int TPM_20_E_159 = unchecked((int)0x80280159);
         private const int ERROR_CANCELLED = unchecked((int)0x800704C7);
+        private const int WINBIO_E_INVALID_TICKET = unchecked((int)0x80098044); // The biometric ticket is incorrect or expired.
         private const int WINBIO_E_DATA_PROTECTION_FAILURE = unchecked((int)0x80098046); // The biometric service could not decrypt the data.
 
         [StructLayout(LayoutKind.Sequential)]
@@ -293,6 +294,12 @@ namespace KeePassWinHello
                 {
                     switch (ex.ErrorCode)
                     {
+                        case WINBIO_E_INVALID_TICKET:          // #113
+                            if (i < Settings.MAX_RETRY_COUNT)
+                                break;
+                            throw new AuthProviderInvalidTicketException(
+                                "Windows Hello could not verify the biometric authentication result. Try unlocking again and choose PIN if biometric authentication continues to fail.",
+                                ex);
                         case TPM_20_E_HANDLE:                  // #68
                         case TPM_20_E_SIZE:                    // #77
                         case TPM_20_E_159:                     // #42

--- a/src/Exceptions/AuthProviderInvalidTicketException.cs
+++ b/src/Exceptions/AuthProviderInvalidTicketException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace KeePassWinHello
+{
+    [Serializable]
+    public class AuthProviderInvalidTicketException : AuthProviderException
+    {
+        public override bool IsPresentable { get { return true; } }
+
+        public AuthProviderInvalidTicketException(string message) : base(message) { }
+        public AuthProviderInvalidTicketException(string message, Exception inner) : base(message, inner) { }
+        protected AuthProviderInvalidTicketException() { }
+        protected AuthProviderInvalidTicketException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/KeePassWinHello.csproj
+++ b/src/KeePassWinHello.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Utilities\ErrorHandler.cs" />
     <Compile Include="Exceptions\AuthProviderIsUnavailableException.cs" />
     <Compile Include="Exceptions\AuthProviderUserCancelledException.cs" />
+    <Compile Include="Exceptions\AuthProviderInvalidTicketException.cs" />
     <Compile Include="Exceptions\AuthProviderInvalidKeyException.cs" />
     <Compile Include="Exceptions\AuthProviderSystemErrorException.cs" />
     <Compile Include="Exceptions\AuthProviderException.cs" />

--- a/src/KeyManagement/KeyManager.cs
+++ b/src/KeyManagement/KeyManager.cs
@@ -70,8 +70,8 @@ namespace KeePassWinHello
             else
             {
                 StopMonitorWarning();
-                RestoreSecureDesktopSettings();
-                Unlock(keyPromptForm, dbPath);
+                bool restartedFromSecureDesktop = RestoreSecureDesktopSettings();
+                Unlock(keyPromptForm, dbPath, restartedFromSecureDesktop);
             }
         }
 
@@ -107,14 +107,17 @@ namespace KeePassWinHello
             CloseFormWithResult(keyPromptForm, DialogResult.OK);
         }
 
-        private void RestoreSecureDesktopSettings()
+        private bool RestoreSecureDesktopSettings()
         {
             int oldTriesValue = Interlocked.Exchange(ref _masterKeyTries, NoChanges);
             if (oldTriesValue != NoChanges)
             {
                 KeePass.Program.Config.Security.MasterKeyTries = oldTriesValue;
                 KeePass.Program.Config.Security.MasterKeyOnSecureDesktop = true;
+                return true;
             }
+
+            return false;
         }
 
         public void OnDBClosing(object sender, FileClosingEventArgs e)
@@ -144,7 +147,7 @@ namespace KeePassWinHello
                 _warningSuppresser = null;
         }
 
-        private void Unlock(KeyPromptForm keyPromptForm, string dbPath)
+        private void Unlock(KeyPromptForm keyPromptForm, string dbPath, bool restartedFromSecureDesktop)
         {
             try
             {
@@ -165,6 +168,12 @@ namespace KeePassWinHello
             catch (AuthProviderUserCancelledException)
             {
                 CloseFormWithResult(keyPromptForm, DialogResult.Cancel);
+            }
+            catch (AuthProviderInvalidTicketException ex)
+            {
+                _uiContextManager.CurrentContext.ShowError(ex);
+                if (restartedFromSecureDesktop)
+                    CloseFormWithResult(keyPromptForm, DialogResult.Cancel);
             }
         }
 
@@ -266,6 +275,10 @@ namespace KeePassWinHello
             {
                 if (Settings.Instance.RevokeOnCancel)
                     _keyStorage.Remove(dbPath);
+                throw;
+            }
+            catch (AuthProviderInvalidTicketException)
+            {
                 throw;
             }
             catch (Exception)


### PR DESCRIPTION
## What changed

- Classified `NCryptDecrypt` status `0x80098044` as `WINBIO_E_INVALID_TICKET`, meaning the biometric ticket is incorrect or expired.
- Added it to the existing transient Windows Hello retry policy. The provider now uses the existing retry UI context, three retries, and two-second delay to request a fresh ticket.
- Added a dedicated presentable `AuthProviderInvalidTicketException` after retry exhaustion.
- Preserved the cached database credential when this ticket error occurs.
- On the normal desktop, the error is shown and KeePass's master-password prompt remains available.
- When KeePass temporarily redirected an unlock from secure desktop, the temporary main-desktop prompt is cancelled after the error so the user's next attempt returns to secure desktop.
- Added the new exception source to the legacy PLGX project.

## Why

The repeated `0x80098044` reports are authentication-ticket failures, not evidence that the Windows Hello-protected key is corrupt. Several reporters can still decrypt the same cached key by selecting PIN after face recognition fails. Automatically revoking the key would therefore destroy valid credentials and, through the existing invalid-key path, could clear unrelated database entries and disable persistent storage.

Retrying is appropriate because the failing object is the short-lived biometric ticket. The retry obtains a fresh ticket and also gives the user another opportunity to choose PIN. If all retries fail, the plugin now degrades to the normal KeePass password flow without changing stored key material.

## Security and state impact

- No Windows Hello key is deleted or recreated.
- No Credential Manager entry is removed.
- No unrelated database cache is touched.
- Persistent storage remains enabled.
- Cancellation and all existing provider-status handling remain unchanged.
- Existing handling for `WINBIO_E_DATA_PROTECTION_FAILURE` (`0x80098046`) remains unchanged.

This prompt-timing and credential-preservation behavior was explicitly approved before implementation.

## Review

An independent review traced the exception through `KeyCipher`, `ProtectedKey`, and `KeyManager`; verified that the dedicated exception bypasses the generic cache-removal path; checked normal and secure-desktop prompt behavior; and confirmed the exact retry count and unchanged handling of other statuses.

The only review finding was unrelated final-newline churn in the legacy project file. That churn was removed, and follow-up review approved the final patch with no remaining findings.

## Validation

- Release/MONO rebuild of `src/KeePassWinHello.csproj`
- `FrameworkPathOverride=C:\Windows\Microsoft.NET\Framework\v4.0.30319`
- `ReferencePath=C:\proj\KeePassWinHello\lib`
- 0 warnings, 0 errors
- `git diff --check`

Manual Windows Hello testing was not performed, because it would require manipulating live biometric/Credential Manager state. Recommended manual coverage is transient and repeated face failures, face failure followed by PIN, local and persistent storage, secure desktop on/off, and elevated/non-elevated KeePass.

Closes #113
Closes #118
Closes #120
Closes #128
Closes #130
Closes #132
Closes #137
Closes #138
Closes #139