### PR TITLE
Fix WINBIO_E_INVALID_TICKET (0x80098044) on face unlock: enforce foreground on the Hello prompt

### DIFF
--- a/src/AuthProviders/WinHelloProvider.cs
+++ b/src/AuthProviders/WinHelloProvider.cs
@@ -34,6 +34,7 @@ namespace KeePassWinHello
         private const int TPM_20_E_SIZE = unchecked((int)0x80280095);
         private const int TPM_20_E_159 = unchecked((int)0x80280159);
         private const int ERROR_CANCELLED = unchecked((int)0x800704C7);
+        private const int WINBIO_E_INVALID_TICKET = unchecked((int)0x80098044); // The biometric ticket is incorrect or expired.
         private const int WINBIO_E_DATA_PROTECTION_FAILURE = unchecked((int)0x80098046); // The biometric service could not decrypt the data.
 
         [StructLayout(LayoutKind.Sequential)]
@@ -287,12 +288,25 @@ namespace KeePassWinHello
             {
                 try
                 {
-                    return PromptToDecrypt(data, retry: i > 0);
+                    return PromptToDecrypt(data, retryMessage: i > 0 ? Settings.FailedRetryMessage : null);
                 }
                 catch (AuthProviderSystemErrorException ex)
                 {
                     switch (ex.ErrorCode)
                     {
+                        case WINBIO_E_INVALID_TICKET:          // #113
+                            // The gesture completed but its ticket was rejected. Seen on the
+                            // first prompt of a fresh KeePass start, when the credential dialog
+                            // loses the foreground race during app startup; a re-prompt with
+                            // restored foreground succeeds (PIN never hits this because typing
+                            // it takes long enough for the window state to settle).
+                            if (i >= Settings.MAX_RETRY_COUNT)
+                                throw new AuthProviderInvalidTicketException(
+                                    "Windows Hello rejected the authentication result. " +
+                                    "If face keeps failing, choose 'More choices' > 'PIN' in the prompt.",
+                                    ex);
+                            BringParentWindowToForegroundSafe();
+                            continue; // the prompt is user-paced, no delay needed
                         case TPM_20_E_HANDLE:                  // #68
                         case TPM_20_E_SIZE:                    // #77
                         case TPM_20_E_159:                     // #42
@@ -306,6 +320,24 @@ namespace KeePassWinHello
 
                     Thread.Sleep(Settings.ATTEMPT_DELAY);
                 }
+            }
+        }
+
+        private void BringParentWindowToForegroundSafe()
+        {
+            try
+            {
+                var uiContext = _uiContextManager.CurrentContext;
+                if (uiContext != null)
+                {
+                    var win = Win32Window.From(uiContext.ParentWindowHandle.Value);
+                    if (win != null)
+                        win.EnsureForeground();
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.Fail(ex.Message);
             }
         }
 
@@ -335,7 +367,7 @@ namespace KeePassWinHello
             return cbResult;
         }
 
-        private byte[] PromptToDecrypt(byte[] data, bool retry)
+        private byte[] PromptToDecrypt(byte[] data, string retryMessage)
         {
             byte[] cbResult;
             SafeNCryptProviderHandle ngcProviderHandle;
@@ -349,7 +381,7 @@ namespace KeePassWinHello
                     if (CurrentCacheType == AuthCacheType.Persistent && !VerifyPersistentKeyIntegrity(ngcKeyHandle))
                         throw new AuthProviderInvalidKeyException(InvalidatedKeyMessage);
 
-                    ApplyUIContext(ngcKeyHandle, retry);
+                    ApplyUIContext(ngcKeyHandle, retryMessage);
 
                     byte[] pinRequired = BitConverter.GetBytes(1);
                     NCryptSetProperty(ngcKeyHandle, NCRYPT_PIN_CACHE_IS_GESTURE_REQUIRED_PROPERTY, pinRequired, pinRequired.Length, CngPropertyOptions.None).ThrowOnError("NCRYPT_PIN_CACHE_IS_GESTURE_REQUIRED_PROPERTY");
@@ -357,7 +389,10 @@ namespace KeePassWinHello
                     // The pbInput and pbOutput parameters can point to the same buffer. In this case, this function will perform the decryption in place.
                     cbResult = new byte[data.Length * 2];
                     int pcbResult;
-                    NCryptDecrypt(ngcKeyHandle, data, data.Length, IntPtr.Zero, cbResult, cbResult.Length, out pcbResult, NCRYPT_PAD_PKCS1_FLAG).ThrowOnError("NCryptDecrypt");
+                    using (CredentialDialogForegroundEnforcer.Start())
+                    {
+                        NCryptDecrypt(ngcKeyHandle, data, data.Length, IntPtr.Zero, cbResult, cbResult.Length, out pcbResult, NCRYPT_PAD_PKCS1_FLAG).ThrowOnError("NCryptDecrypt");
+                    }
                     // TODO: secure resize
                     Array.Resize(ref cbResult, pcbResult);
                 }
@@ -477,7 +512,71 @@ namespace KeePassWinHello
             return ngcKeyHandle;
         }
 
-        private void ApplyUIContext(SafeNCryptKeyHandle ngcKeyHandle, bool retryMessage = false)
+        // The Windows Hello credential dialog is hosted in another process; if it
+        // does not own the foreground when a biometric gesture completes, the
+        // service rejects the resulting ticket (WINBIO_E_INVALID_TICKET, #113).
+        // Typical on the first prompt of a fresh KeePass start, while the app is
+        // still winning the activation race, so keep pushing the dialog to the
+        // foreground for the first couple of seconds of each prompt.
+        private sealed class CredentialDialogForegroundEnforcer : IDisposable
+        {
+#if DEBUG
+            private const string CredentialDialogClass = null;
+#else
+            private const string CredentialDialogClass = "Credential Dialog Xaml Host";
+#endif
+            private const string CredentialDialogTitle = "Windows Security";
+            private const int DialogAppearanceTimeoutMs = 5000;
+            private const int EnforcementAttempts = 20;
+            private const int EnforcementIntervalMs = 100;
+
+            private volatile bool _stopped;
+
+            private CredentialDialogForegroundEnforcer() { }
+
+            public static IDisposable Start()
+            {
+                var enforcer = new CredentialDialogForegroundEnforcer();
+                try
+                {
+                    Win32Window.AllowAllSetForeground();
+                    var thread = new Thread(enforcer.Run) { IsBackground = true };
+                    thread.Start();
+                }
+                catch (Exception ex)
+                {
+                    Debug.Fail(ex.Message);
+                }
+                return enforcer;
+            }
+
+            private void Run()
+            {
+                try
+                {
+                    var dialog = Win32Window.Find(CredentialDialogClass, CredentialDialogTitle, DialogAppearanceTimeoutMs);
+                    for (int i = 0; i < EnforcementAttempts && !_stopped && dialog != null; ++i)
+                    {
+                        if (dialog.IsWindowOnForeground())
+                            return;
+                        try { dialog.EnsureForeground(); } catch { }
+                        Thread.Sleep(EnforcementIntervalMs);
+                        dialog = Win32Window.Find(CredentialDialogClass, CredentialDialogTitle);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.Fail(ex.Message);
+                }
+            }
+
+            public void Dispose()
+            {
+                _stopped = true;
+            }
+        }
+
+        private void ApplyUIContext(SafeNCryptKeyHandle ngcKeyHandle, string retryMessage = null)
         {
             var uiContext = _uiContextManager.CurrentContext;
             if (uiContext != null)
@@ -491,8 +590,8 @@ namespace KeePassWinHello
                 }
 
                 string message = uiContext.Message;
-                if (retryMessage)
-                    message = Settings.FailedRetryMessage + message;
+                if (!string.IsNullOrEmpty(retryMessage))
+                    message = retryMessage + message;
 
                 if (!string.IsNullOrEmpty(message))
                     NCryptSetProperty(ngcKeyHandle, NCRYPT_USE_CONTEXT_PROPERTY, message, (message.Length + 1) * 2, CngPropertyOptions.None).ThrowOnError("NCRYPT_USE_CONTEXT_PROPERTY");

--- a/src/Exceptions/AuthProviderInvalidTicketException.cs
+++ b/src/Exceptions/AuthProviderInvalidTicketException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace KeePassWinHello
+{
+    [Serializable]
+    public class AuthProviderInvalidTicketException : AuthProviderException
+    {
+        public override bool IsPresentable { get { return true; } }
+
+        public AuthProviderInvalidTicketException(string message) : base(message) { }
+        public AuthProviderInvalidTicketException(string message, Exception inner) : base(message, inner) { }
+        protected AuthProviderInvalidTicketException() { }
+        protected AuthProviderInvalidTicketException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/KeePassWinHello.Debug.csproj
+++ b/src/KeePassWinHello.Debug.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>KeePassWinHello</AssemblyName>
 
     <Configurations>Debug;Release;DebugDummy</Configurations>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <DefineConstants Condition="'$(Configuration)'=='DebugDummy'">$(DefineConstants);DUMMY_PROVIDER</DefineConstants>
   </PropertyGroup>
 
@@ -47,6 +48,9 @@
     <Content Include="Resources\KPWH_16x16.png" />
     <Content Include="Resources\KPWH_32x32.png" />
     <Content Include="Resources\KPWH_512x512.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 
   <Target Name="PackPlugin" AfterTargets="PostBuildEvent" Condition="!($(DefineConstants.Contains('MONO')))">

--- a/src/KeePassWinHello.csproj
+++ b/src/KeePassWinHello.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Utilities\ErrorHandler.cs" />
     <Compile Include="Exceptions\AuthProviderIsUnavailableException.cs" />
     <Compile Include="Exceptions\AuthProviderUserCancelledException.cs" />
+    <Compile Include="Exceptions\AuthProviderInvalidTicketException.cs" />
     <Compile Include="Exceptions\AuthProviderInvalidKeyException.cs" />
     <Compile Include="Exceptions\AuthProviderSystemErrorException.cs" />
     <Compile Include="Exceptions\AuthProviderException.cs" />

--- a/src/KeyManagement/KeyManager.cs
+++ b/src/KeyManagement/KeyManager.cs
@@ -70,15 +70,15 @@ namespace KeePassWinHello
             else
             {
                 StopMonitorWarning();
-                RestoreSecureDesktopSettings();
-                Unlock(keyPromptForm, dbPath);
+                bool restartedFromSecureDesktop = RestoreSecureDesktopSettings();
+                Unlock(keyPromptForm, dbPath, restartedFromSecureDesktop);
             }
         }
 
         private void RestartPromptOnMainDesktopAndSuppressWarning(KeyPromptForm keyPromptForm)
         {
             IDisposable warningSuppresser = null;
-            if (Volatile.Read(ref _warningSuppresser) == null)
+            if (Interlocked.CompareExchange(ref _warningSuppresser, null, null) == null) // Volatile.Read is unavailable in net4.0
                 warningSuppresser = KeePassWarningSuppresser.SuppressAllWarningWindows(_uiContextManager);
 
             try
@@ -107,14 +107,17 @@ namespace KeePassWinHello
             CloseFormWithResult(keyPromptForm, DialogResult.OK);
         }
 
-        private void RestoreSecureDesktopSettings()
+        private bool RestoreSecureDesktopSettings()
         {
             int oldTriesValue = Interlocked.Exchange(ref _masterKeyTries, NoChanges);
             if (oldTriesValue != NoChanges)
             {
                 KeePass.Program.Config.Security.MasterKeyTries = oldTriesValue;
                 KeePass.Program.Config.Security.MasterKeyOnSecureDesktop = true;
+                return true;
             }
+
+            return false;
         }
 
         public void OnDBClosing(object sender, FileClosingEventArgs e)
@@ -144,7 +147,7 @@ namespace KeePassWinHello
                 _warningSuppresser = null;
         }
 
-        private void Unlock(KeyPromptForm keyPromptForm, string dbPath)
+        private void Unlock(KeyPromptForm keyPromptForm, string dbPath, bool restartedFromSecureDesktop)
         {
             try
             {
@@ -165,6 +168,12 @@ namespace KeePassWinHello
             catch (AuthProviderUserCancelledException)
             {
                 CloseFormWithResult(keyPromptForm, DialogResult.Cancel);
+            }
+            catch (AuthProviderInvalidTicketException ex)
+            {
+                _uiContextManager.CurrentContext.ShowError(ex);
+                if (restartedFromSecureDesktop)
+                    CloseFormWithResult(keyPromptForm, DialogResult.Cancel);
             }
         }
 
@@ -266,6 +275,10 @@ namespace KeePassWinHello
             {
                 if (Settings.Instance.RevokeOnCancel)
                     _keyStorage.Remove(dbPath);
+                throw;
+            }
+            catch (AuthProviderInvalidTicketException)
+            {
                 throw;
             }
             catch (Exception)

--- a/tools/HelloTicketProbe/HelloTicketProbe.csproj
+++ b/tools/HelloTicketProbe/HelloTicketProbe.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <Nullable>disable</Nullable>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/tools/HelloTicketProbe/Program.cs
+++ b/tools/HelloTicketProbe/Program.cs
@@ -1,0 +1,292 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Text;
+
+namespace HelloTicketProbe
+{
+    // Standalone repro of KeePassWinHello's NGC key usage, to diagnose
+    // WINBIO_E_INVALID_TICKET (0x80098044) on face auth without KeePass in the loop.
+    internal static class Program
+    {
+        private const string MS_NGC_KEY_STORAGE_PROVIDER = "Microsoft Passport Key Storage Provider";
+        private const string NCRYPT_WINDOW_HANDLE_PROPERTY = "HWND Handle";
+        private const string NCRYPT_USE_CONTEXT_PROPERTY = "Use Context";
+        private const string NCRYPT_LENGTH_PROPERTY = "Length";
+        private const string NCRYPT_KEY_USAGE_PROPERTY = "Key Usage";
+        private const string NCRYPT_NGC_CACHE_TYPE_PROPERTY = "NgcCacheType";
+        private const string NCRYPT_PIN_CACHE_IS_GESTURE_REQUIRED_PROPERTY = "PinCacheIsGestureRequired";
+        private const string BCRYPT_RSA_ALGORITHM = "RSA";
+        private const int NCRYPT_NGC_CACHE_TYPE_PROPERTY_AUTH_MANDATORY_FLAG = 0x00000001;
+        private const int NCRYPT_ALLOW_DECRYPT_FLAG = 0x00000001;
+        private const int NCRYPT_ALLOW_SIGNING_FLAG = 0x00000002;
+        private const int NCRYPT_PAD_PKCS1_FLAG = 0x00000002;
+        private const int NCRYPT_OVERWRITE_KEY_FLAG = 0x00000080;
+        private const int NCRYPT_SILENT_FLAG = 0x00000040;
+        private const int NTE_NO_KEY = unchecked((int)0x8009000D);
+        private const int NTE_USER_CANCELLED = unchecked((int)0x80090036);
+        private const int WINBIO_E_INVALID_TICKET = unchecked((int)0x80098044);
+
+        [DllImport("cryptngc.dll", CharSet = CharSet.Unicode)]
+        private static extern int NgcGetDefaultDecryptionKeyName(string pszSid, int dwReserved1, int dwReserved2, out string ppszKeyName);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode)]
+        private static extern int NCryptOpenStorageProvider(out IntPtr phProvider, string pszProviderName, int dwFlags);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode)]
+        private static extern int NCryptOpenKey(IntPtr hProvider, out IntPtr phKey, string pszKeyName, int dwLegacyKeySpec, int dwFlags);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode)]
+        private static extern int NCryptCreatePersistedKey(IntPtr hProvider, out IntPtr phKey, string pszAlgId, string pszKeyName, int dwLegacyKeySpec, int dwFlags);
+
+        [DllImport("ncrypt.dll")]
+        private static extern int NCryptFinalizeKey(IntPtr hKey, int dwFlags);
+
+        [DllImport("ncrypt.dll")]
+        private static extern int NCryptDeleteKey(IntPtr hKey, int flags);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode)]
+        private static extern int NCryptSetProperty(IntPtr hObject, string pszProperty, byte[] pbInput, int cbInput, int dwFlags);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode)]
+        private static extern int NCryptSetProperty(IntPtr hObject, string pszProperty, string pbInput, int cbInput, int dwFlags);
+
+        [DllImport("ncrypt.dll")]
+        private static extern int NCryptEncrypt(IntPtr hKey, byte[] pbInput, int cbInput, IntPtr pvPaddingZero, byte[] pbOutput, int cbOutput, out int pcbResult, int dwFlags);
+
+        [DllImport("ncrypt.dll")]
+        private static extern int NCryptDecrypt(IntPtr hKey, byte[] pbInput, int cbInput, IntPtr pvPaddingZero, byte[] pbOutput, int cbOutput, out int pcbResult, int dwFlags);
+
+        [DllImport("ncrypt.dll")]
+        private static extern int NCryptFreeObject(IntPtr hObject);
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GetConsoleWindow();
+
+        private static string _logPath;
+        private static string _sid;
+
+        private static void Log(string message)
+        {
+            var line = string.Format("{0:HH:mm:ss.fff} {1}", DateTime.Now, message);
+            Console.WriteLine(line);
+            try { File.AppendAllText(_logPath, line + Environment.NewLine); } catch { }
+        }
+
+        private static string Hr(int hr)
+        {
+            return hr == 0 ? "OK" : string.Format("0x{0:X8}", hr);
+        }
+
+        private static int Main()
+        {
+            _logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "probe-log.txt");
+            _sid = WindowsIdentity.GetCurrent().User.ToString();
+
+            Log("==================================================================");
+            Log(string.Format("Probe start. OS build: {0}. Log: {1}", Environment.OSVersion.Version, _logPath));
+
+            string defaultKey;
+            int hr = NgcGetDefaultDecryptionKeyName(_sid, 0, 0, out defaultKey);
+            Log(string.Format("NgcGetDefaultDecryptionKeyName: {0}, key present: {1}", Hr(hr), !string.IsNullOrEmpty(defaultKey)));
+            if (string.IsNullOrEmpty(defaultKey))
+            {
+                Log("Windows Hello is not available for this account. Aborting.");
+                return 1;
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("IMPORTANT: for a meaningful test, run this right after signing into");
+            Console.WriteLine("Windows with FACE, before any PIN has been entered in this session.");
+            Console.WriteLine();
+
+            // Same name construction as WinHelloProvider: SID//Domain/SubDomain/Name
+            string pluginKeyName = _sid + "//KeePassWinHello//KeePassWinHello";
+            RunPhase("PHASE 1: plugin's existing persistent key", pluginKeyName, createFresh: false);
+
+            string probeKeyName = _sid + "//KPWHProbe//KPWHProbe";
+            RunPhase("PHASE 2: freshly created key", probeKeyName, createFresh: true);
+
+            Console.WriteLine();
+            Log("Probe finished. Send probe-log.txt back for analysis.");
+            Console.WriteLine("Press any key to exit.");
+            Console.ReadKey(true);
+            return 0;
+        }
+
+        private static void RunPhase(string title, string keyName, bool createFresh)
+        {
+            Console.WriteLine();
+            Log("---- " + title + " ----");
+            Log("Key name: " + keyName);
+
+            Console.WriteLine("Press Y to run this phase, any other key to skip.");
+            if (char.ToUpperInvariant(Console.ReadKey(true).KeyChar) != 'Y')
+            {
+                Log("Phase skipped by user.");
+                return;
+            }
+
+            IntPtr provider;
+            int hr = NCryptOpenStorageProvider(out provider, MS_NGC_KEY_STORAGE_PROVIDER, 0);
+            Log("NCryptOpenStorageProvider: " + Hr(hr));
+            if (hr != 0) return;
+
+            try
+            {
+                if (createFresh)
+                {
+                    if (!CreateKey(provider, keyName))
+                        return;
+                }
+
+                byte[] plain = Encoding.ASCII.GetBytes("HelloTicketProbe-test-payload-01");
+                byte[] cipher = EncryptBlob(provider, keyName, plain);
+                if (cipher == null) return;
+
+                // Attempt 1: expect the user to authenticate with FACE.
+                Console.WriteLine();
+                Console.WriteLine(">>> A Windows Hello prompt will appear. Use FACE (let it scan).");
+                Console.WriteLine(">>> Press any key to show the prompt...");
+                Console.ReadKey(true);
+                int hrFace = DecryptBlob(provider, keyName, cipher, plain, "face attempt");
+
+                if (hrFace == WINBIO_E_INVALID_TICKET)
+                {
+                    // Attempt 2: same call, but the user picks PIN in the dialog.
+                    Console.WriteLine();
+                    Console.WriteLine(">>> Prompt again. This time click 'More choices' and select PIN.");
+                    Console.WriteLine(">>> Press any key to show the prompt...");
+                    Console.ReadKey(true);
+                    int hrPin = DecryptBlob(provider, keyName, cipher, plain, "PIN attempt");
+
+                    if (hrPin == 0)
+                    {
+                        // Did the PIN repair the session for biometrics?
+                        Console.WriteLine();
+                        Console.WriteLine(">>> Prompt once more. Use FACE again to see if it now works.");
+                        Console.WriteLine(">>> Press any key to show the prompt...");
+                        Console.ReadKey(true);
+                        DecryptBlob(provider, keyName, cipher, plain, "face after PIN");
+                    }
+                }
+            }
+            finally
+            {
+                if (createFresh)
+                    DeleteKey(provider, keyName);
+                NCryptFreeObject(provider);
+            }
+        }
+
+        private static bool CreateKey(IntPtr provider, string keyName)
+        {
+            IntPtr key;
+            int hr = NCryptCreatePersistedKey(provider, out key, BCRYPT_RSA_ALGORITHM, keyName, 0, NCRYPT_OVERWRITE_KEY_FLAG);
+            Log("NCryptCreatePersistedKey: " + Hr(hr));
+            if (hr != 0) return false;
+
+            byte[] length = BitConverter.GetBytes(2048);
+            hr = NCryptSetProperty(key, NCRYPT_LENGTH_PROPERTY, length, length.Length, 0);
+            Log("  set Length: " + Hr(hr));
+
+            byte[] usage = BitConverter.GetBytes(NCRYPT_ALLOW_DECRYPT_FLAG | NCRYPT_ALLOW_SIGNING_FLAG);
+            hr = NCryptSetProperty(key, NCRYPT_KEY_USAGE_PROPERTY, usage, usage.Length, 0);
+            Log("  set Key Usage: " + Hr(hr));
+
+            byte[] cacheType = BitConverter.GetBytes(NCRYPT_NGC_CACHE_TYPE_PROPERTY_AUTH_MANDATORY_FLAG);
+            hr = NCryptSetProperty(key, NCRYPT_NGC_CACHE_TYPE_PROPERTY, cacheType, cacheType.Length, 0);
+            Log("  set NgcCacheType: " + Hr(hr));
+
+            ApplyUIContext(key, "HelloTicketProbe: creating test key");
+
+            Console.WriteLine(">>> Finalizing the key may show a Windows Hello prompt. Authenticate however you like.");
+            hr = NCryptFinalizeKey(key, 0);
+            Log("NCryptFinalizeKey: " + Hr(hr));
+            NCryptFreeObject(key);
+            return hr == 0;
+        }
+
+        private static void DeleteKey(IntPtr provider, string keyName)
+        {
+            IntPtr key;
+            int hr = NCryptOpenKey(provider, out key, keyName, 0, 0);
+            if (hr != 0) { Log("cleanup NCryptOpenKey: " + Hr(hr)); return; }
+            hr = NCryptDeleteKey(key, 0);
+            Log("cleanup NCryptDeleteKey: " + Hr(hr));
+            if (hr != 0) NCryptFreeObject(key);
+        }
+
+        private static byte[] EncryptBlob(IntPtr provider, string keyName, byte[] plain)
+        {
+            IntPtr key;
+            int hr = NCryptOpenKey(provider, out key, keyName, 0, NCRYPT_SILENT_FLAG);
+            Log("NCryptOpenKey (silent, for encrypt): " + Hr(hr) + (hr == NTE_NO_KEY ? " [key does not exist]" : ""));
+            if (hr != 0) return null;
+
+            try
+            {
+                int cb;
+                hr = NCryptEncrypt(key, plain, plain.Length, IntPtr.Zero, null, 0, out cb, NCRYPT_PAD_PKCS1_FLAG);
+                if (hr != 0) { Log("NCryptEncrypt (size): " + Hr(hr)); return null; }
+                byte[] cipher = new byte[cb];
+                hr = NCryptEncrypt(key, plain, plain.Length, IntPtr.Zero, cipher, cipher.Length, out cb, NCRYPT_PAD_PKCS1_FLAG);
+                Log("NCryptEncrypt: " + Hr(hr));
+                return hr == 0 ? cipher : null;
+            }
+            finally
+            {
+                NCryptFreeObject(key);
+            }
+        }
+
+        private static int DecryptBlob(IntPtr provider, string keyName, byte[] cipher, byte[] expectedPlain, string label)
+        {
+            IntPtr key;
+            int hr = NCryptOpenKey(provider, out key, keyName, 0, 0);
+            Log(string.Format("NCryptOpenKey ({0}): {1}", label, Hr(hr)));
+            if (hr != 0) return hr;
+
+            try
+            {
+                ApplyUIContext(key, "HelloTicketProbe: " + label);
+
+                byte[] gestureRequired = BitConverter.GetBytes(1);
+                hr = NCryptSetProperty(key, NCRYPT_PIN_CACHE_IS_GESTURE_REQUIRED_PROPERTY, gestureRequired, gestureRequired.Length, 0);
+                Log("  set PinCacheIsGestureRequired: " + Hr(hr));
+
+                byte[] output = new byte[cipher.Length];
+                int cb;
+                hr = NCryptDecrypt(key, cipher, cipher.Length, IntPtr.Zero, output, output.Length, out cb, NCRYPT_PAD_PKCS1_FLAG);
+                bool roundTrip = false;
+                if (hr == 0 && cb == expectedPlain.Length)
+                {
+                    roundTrip = true;
+                    for (int i = 0; i < cb; ++i)
+                        if (output[i] != expectedPlain[i]) { roundTrip = false; break; }
+                }
+                Log(string.Format("NCryptDecrypt ({0}): {1}{2}", label, Hr(hr),
+                    hr == 0 ? (roundTrip ? " [payload verified]" : " [PAYLOAD MISMATCH]")
+                    : hr == WINBIO_E_INVALID_TICKET ? " [WINBIO_E_INVALID_TICKET]"
+                    : hr == NTE_USER_CANCELLED ? " [user cancelled]" : ""));
+                return hr;
+            }
+            finally
+            {
+                NCryptFreeObject(key);
+            }
+        }
+
+        private static void ApplyUIContext(IntPtr key, string message)
+        {
+            IntPtr hwnd = GetConsoleWindow();
+            if (hwnd != IntPtr.Zero)
+            {
+                byte[] handle = BitConverter.GetBytes(IntPtr.Size == 8 ? hwnd.ToInt64() : hwnd.ToInt32());
+                NCryptSetProperty(key, NCRYPT_WINDOW_HANDLE_PROPERTY, handle, handle.Length, 0);
+            }
+            NCryptSetProperty(key, NCRYPT_USE_CONTEXT_PROPERTY, message, (message.Length + 1) * 2, 0);
+        }
+    }
+}


### PR DESCRIPTION
## The bug

Face unlock fails with `NCryptDecrypt` → `0x80098044` (`WINBIO_E_INVALID_TICKET`) on the **first prompt of a fresh KeePass launch**, while PIN always works — reported in #113, #118, #120, #128, #130, #132, #137, #138, #139.

## Root cause

It's a **foreground race**, not a stale ticket, key corruption, or Windows-session state. The Windows Hello credential dialog ("Windows Security", class `Credential Dialog Xaml Host`) is hosted in another process. During KeePass startup the dialog can lose the foreground to KeePass's own appearing windows, and Windows rejects a biometric gesture ticket that completes against a non-foreground dialog. This is the same failure mode Bitwarden confirmed in their desktop app ("Windows Hello fails if the prompt is not in the foreground").

The evidence, gathered on a machine reproducing this 100% of the time (Windows 11 Pro 25H2, no Enhanced Sign-in Security):

- Fresh KeePass open → face fails, PIN works. Same process, lock and reopen the database → **face works**. Reboots and sign-out/in change nothing — it is per-*first-prompt-of-launch*, not per-session.
- A standalone console harness (`tools/HelloTicketProbe`, included in this PR) replaying the plugin's exact NGC/NCrypt call sequence against the same persistent key **never fails** — a console app the user just interacted with is always foreground.
- PIN "working" is the tell: typing a PIN takes seconds, by which time window activation has settled. Face auto-scans instantly, inside the race window.

This also explains why plain retry loops (the approach in #158) don't fix it: each retried prompt hits the same unsettled foreground state. The missing ingredient is foreground enforcement, which this repo already had — `WinHelloProviderForegroundDecorator` — but it only activates when KeePass runs **elevated**, and only once per unlock rather than per prompt attempt.

## The fix

- `CredentialDialogForegroundEnforcer` (in `WinHelloProvider`): around **every** `NCryptDecrypt` prompt, grant foreground rights (`AllowSetForegroundWindow(ASFW_ANY)`) and keep pushing the credential dialog to the foreground (~2 s, 100 ms cadence, stops as soon as the dialog is foreground) — the same technique the elevated-only decorator used, now applied to every prompt regardless of elevation.
- On `WINBIO_E_INVALID_TICKET`: bring the parent window to the front and immediately re-prompt (no artificial delay — the prompt is user-paced), with the retry also running under the enforcer.
- If all retries fail, throw a presentable `AuthProviderInvalidTicketException` suggesting the PIN option instead of surfacing a raw `0x80098044`.
- Repairs `KeyManager.cs` (net4.0-compatible `Interlocked.CompareExchange` instead of `Volatile.Read`) and adds the `HelloTicketProbe` diagnostic harness used during the investigation.

## Testing

On hardware reproducing the bug on every fresh launch: with this change, face unlock succeeds on the first prompt of a fresh KeePass start. Subsequent unlocks unaffected. PIN path unaffected.

Closes #113, closes #118, closes #120, closes #128, closes #130, closes #132, closes #137, closes #138, closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)